### PR TITLE
feature: super slim dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,9 @@ services:
   server:
     image: arguflow/server:no-ocr
     container_name: server
-    build: ./server/
+    build: 
+      context: ./server/
+      dockerfile: Dockerfile.no-ocr
     depends_on:
       tika:
         condition: service_healthy

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -83,6 +83,6 @@ cfg-if = "1.0.0"
 dotenvy = "0.15.7"
 
 [features]
-default = ["ocr"]
+default = []
 runtime-env = []
 ocr = ["dep:pyo3", "dep:magick_rust"]

--- a/server/Dockerfile.no-ocr
+++ b/server/Dockerfile.no-ocr
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly-bookworm AS chef
+FROM rust:1.75-bookworm AS chef
 # We only pay the installation cost once, 
 # it will be cached from the second build onwards
 RUN cargo install cargo-chef 
@@ -11,20 +11,22 @@ RUN cargo chef prepare  --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json --no-default-features
+RUN cargo chef cook --release --recipe-path recipe.json
 # Build application
-COPY . .
-RUN cargo build --release --no-default-features --features "runtime-env", 
+COPY ./src .
+COPY ./Cargo.toml .
+COPY ./Cargo.lock .
+RUN cargo build --release --features "runtime-env"
 
 # Use Ubuntu 22.04 as the base image
 FROM python:3.9-slim-bookworm as runtime
 RUN apt-get update -y && apt-get -y install libpq-dev
 WORKDIR /app
-COPY --from=builder /app/target/release/trieve-server /app/trieve-server
 COPY ./server-python/requirements.txt /app/requirements.txt
 RUN pip install --break-system-packages -r /app/requirements.txt;
 COPY ./migrations/ /app/migrations
 COPY ./server-python/ /app/server-python
+COPY --from=builder /app/target/release/trieve-server /app/trieve-server
 
 
 EXPOSE 8090

--- a/server/Dockerfile.no-ocr
+++ b/server/Dockerfile.no-ocr
@@ -1,6 +1,7 @@
-FROM rust:1.75-bookworm AS chef
+FROM rust:1.75-slim-bookworm AS chef
 # We only pay the installation cost once, 
 # it will be cached from the second build onwards
+RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev
 RUN cargo install cargo-chef 
 WORKDIR app
 

--- a/server/Dockerfile.ocr
+++ b/server/Dockerfile.ocr
@@ -55,9 +55,9 @@ RUN set -eux; \
 FROM builder-base as builder
 WORKDIR app
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --features "ocr"
 COPY . .
-RUN cargo build --release --no-default-features --features "runtime-env ocr", 
+RUN cargo build --release --features "runtime-env ocr"
 
 FROM dpokidov/imagemagick:7.1.1-21-bookworm as runtime
 RUN apt-get update; \

--- a/server/server-python/requirements.txt
+++ b/server/server-python/requirements.txt
@@ -1,4 +1,2 @@
-python-dotenv==1.0.0
-qdrant_client==1.7.0
 bs4==0.0.1
 english_dictionary==1.0.24


### PR DESCRIPTION
Dockerfile.no-ocr is halved in size at 228MB and caches properly using
rust:1.75 instead of rust-nightly, hopefully will reduce the amount of full
builds
