### PR TITLE
feature: cast result from embedding server

### DIFF
--- a/embedding-server/embeddings.py
+++ b/embedding-server/embeddings.py
@@ -93,7 +93,7 @@ async def encode(encodingRequest: EncodeRequest):
             "data": [
                 {
                     "object": "embedding",
-                    "embedding": sentence_embeddings[0],
+                    "embedding": list(sentence_embeddings[0].astype(float)),
                     "index": 0,
                 }
             ],


### PR DESCRIPTION
The new model returns the wrong ndarray of float32's casted to floats and list
