### PR TITLE
bugfix: skip json parsing, explicitly set value as float

### DIFF
--- a/server/src/bin/ingestion-microservice.rs
+++ b/server/src/bin/ingestion-microservice.rs
@@ -130,7 +130,7 @@ async fn upload_chunk(
     let duplicate_distance_threshold = payload
         .dataset_config
         .DUPLICATE_DISTANCE_THRESHOLD
-        .unwrap_or(1.1);
+        .unwrap_or(1.1f32);
 
     if duplicate_distance_threshold > 1.0
         || payload.dataset_config.COLLISIONS_ENABLED.unwrap_or(false)

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -883,8 +883,7 @@ impl ServerDatasetConfiguration {
                 .map(|u| u as usize),
             DUPLICATE_DISTANCE_THRESHOLD: configuration
                 .get("DUPLICATE_DISTANCE_THRESHOLD")
-                .unwrap_or(&json!(1.1))
-                .as_f64()
+                .and_then(|v| v.as_f64())
                 .map(|f| f as f32),
             EMBEDDING_SIZE: configuration
                 .get("EMBEDDING_SIZE")


### PR DESCRIPTION
## Relates to:
bugfix: DUPLICATE_THRESHOLD configuration param defaulting to 1.100000023841858 instead of 1.1 https://github.com/devflowinc/trieve/issues/877

## Glide Triage
### Thoughts:

The task involves addressing a bug related to the `DUPLICATE_DISTANCE_THRESHOLD` configuration parameter defaulting to an incorrect floating-point value due to precision issues when converting from JSON to an f64 and then using it as an f32. The code context provided includes the `ServerDatasetConfiguration` struct where the `DUPLICATE_DISTANCE_THRESHOLD` is defined as an `Option<f32>`, and the `upload_chunk` function where this threshold is used to determine if a collision (duplicate) has occurred.

### Solution sketch:

1. Identify where the `DUPLICATE_DISTANCE_THRESHOLD` is being parsed from JSON and converted to an f64, which is then cast to an f32. This is likely the root cause of the precision issue.
2. Modify the parsing logic to ensure that the value is directly parsed as an `f32` to avoid precision loss. If using the `serde_json` library, consider using the `as_f32()` method if available, or use the `as_f64()` method followed by a cast to `f32` to handle the conversion from JSON to `f32` without introducing precision issues.
3. Review the `ServerDatasetConfiguration::from_json` method to ensure that the `DUPLICATE_DISTANCE_THRESHOLD` is being handled correctly during the conversion from JSON.
4. Update the `upload_chunk` function to use the corrected `DUPLICATE_DISTANCE_THRESHOLD` value. Ensure that the default value of `1.1` is specified as an f32 literal (`1.1f32`) to avoid any implicit type conversions that could introduce precision errors.