### PR TITLE
Tf/test window env

### DIFF
--- a/search/.dockerignore
+++ b/search/.dockerignore
@@ -1,2 +1,3 @@
+/dist
 /node_modules
 .env

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,11 +1,26 @@
-FROM node:18-alpine3.18 AS runtime
+FROM node:18 as build
+
 WORKDIR /app
 
-RUN apk update && apk add --no-cache openssl-dev libpq pkgconfig build-base
-COPY package.json yarn.lock ./
-RUN yarn install
+COPY package*.json ./
+
 COPY . .
-ENV HOST=0.0.0.0 \
-    PORT=3000
-EXPOSE 3000
-CMD yarn build && node ./dist/server/entry.mjs
+
+RUN yarn install
+RUN yarn run build
+
+FROM nginx:1.25.4-alpine-slim
+
+WORKDIR /usr/share/nginx/html
+
+COPY --from=build /app/dist /usr/share/nginx/html
+# below hack only seems to work if the container isn't built with corresponding vite variable
+COPY <<EOF /docker-entrypoint.d/99-insert.sh
+#!/bin/sh 
+if [ -n "$API_HOST" ]; then
+  echo "window.API_HOST = '$API_HOST';"
+fi
+EOF
+
+EXPOSE 80
+

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -15,12 +15,19 @@ WORKDIR /usr/share/nginx/html
 
 COPY --from=build /app/dist /usr/share/nginx/html
 # below hack only seems to work if the container isn't built with corresponding vite variable
-COPY <<EOF /docker-entrypoint.d/99-insert.sh
-#!/bin/sh 
+
+COPY <<'EOF' /docker-entrypoint.d/01-insert-window-variable.sh
+#!/bin/sh
+
+set -eu
+
 if [ -n "$API_HOST" ]; then
-  echo "window.API_HOST = '$API_HOST';"
+  echo API_HOST variable found
+  echo "window.API_HOST='$API_HOST';" >> /usr/share/nginx/html/env.js
 fi
 EOF
+
+RUN chmod +x /docker-entrypoint.d/01-insert-window-variable.sh
 
 EXPOSE 80
 

--- a/search/README.md
+++ b/search/README.md
@@ -1,0 +1,7 @@
+# Readme
+
+Build with vite env's and run with docker run / compose
+
+If you want to configure API_HOST at runtime, build without vite envs
+
+`docker run -p 8080:80 --env API_HOST="localhost:1234" nginx-test`

--- a/search/README.md
+++ b/search/README.md
@@ -5,3 +5,10 @@ Build with vite env's and run with docker run / compose
 If you want to configure API_HOST at runtime, build without vite envs
 
 `docker run -p 8080:80 --env API_HOST="localhost:1234" nginx-test`
+
+Alternatively you can mount env.js as a docker volume under `/usr/share/nginx/html/env.js`
+
+
+``` env.js
+window.API_HOST=http://localhost:4321;"
+```

--- a/search/index.html
+++ b/search/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <script src="/env.js"></script>
     <script src="https://cdn.tiny.cloud/1/cgddj0590kp8ld81hph2qvbg0m2zd5jvcodbfpj82sah3lvf/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
     <script is:inline>
       const theme = (() => {

--- a/search/public/env.js
+++ b/search/public/env.js
@@ -1,0 +1,1 @@
+window.API_HOST="http://localhost:5176"

--- a/search/public/env.js
+++ b/search/public/env.js
@@ -1,1 +1,1 @@
-window.API_HOST="http://localhost:5176"
+// add window objects here

--- a/search/public/env.js
+++ b/search/public/env.js
@@ -1,1 +1,2 @@
-// add window objects here
+// add window variables here
+

--- a/search/src/components/BookmarkPopover.tsx
+++ b/search/src/components/BookmarkPopover.tsx
@@ -31,7 +31,7 @@ export interface BookmarkPopoverProps {
 }
 
 const BookmarkPopover = (props: BookmarkPopoverProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const $currentUser = useStore(currentUser);
 

--- a/search/src/components/ChatPopup.tsx
+++ b/search/src/components/ChatPopup.tsx
@@ -27,7 +27,7 @@ export interface LayoutProps {
 }
 
 const ChatPopup = (props: LayoutProps) => {
-  const api_host = import.meta.env.VITE_API_HOST as unknown as string;
+  const api_host = window.API_HOST || import.meta.env.VITE_API_HOST as unknown as string;
   const $dataset = useStore(currentDataset);
   const resizeTextarea = (textarea: HTMLTextAreaElement) => {
     textarea.style.height = "auto";

--- a/search/src/components/ChunkMetadataDisplay.tsx
+++ b/search/src/components/ChunkMetadataDisplay.tsx
@@ -60,7 +60,7 @@ export interface ChunkMetadataDisplayProps {
 }
 
 const ChunkMetadataDisplay = (props: ChunkMetadataDisplayProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $envs = useStore(clientConfig);
 
   const frontMatterValsToHide = $envs().FRONTMATTER_VALS?.split(",");

--- a/search/src/components/CreateNewDocChunkForm.tsx
+++ b/search/src/components/CreateNewDocChunkForm.tsx
@@ -12,7 +12,7 @@ import { useStore } from "@nanostores/solid";
 import { currentDataset } from "../stores/datasetStore";
 
 export const CreateNewDocChunkForm = () => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const [docChunkLink, setDocChunkLink] = createSignal("");
   const [tagSet, setTagSet] = createSignal("");

--- a/search/src/components/EditChunkPageForm.tsx
+++ b/search/src/components/EditChunkPageForm.tsx
@@ -17,7 +17,7 @@ import { useStore } from "@nanostores/solid";
 import { currentDataset } from "../stores/datasetStore";
 
 export const EditChunkPageForm = (props: SingleChunkPageProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const initialChunkMetadata = props.defaultResultChunk.metadata;
 

--- a/search/src/components/EditUserForm.tsx
+++ b/search/src/components/EditUserForm.tsx
@@ -4,7 +4,7 @@ import { currentUser } from "../stores/userStore";
 import { useStore } from "@nanostores/solid";
 
 const SearchForm = () => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $currentUser = useStore(currentUser);
   const [username, setUsername] = createSignal("");
   const [website, setWebsite] = createSignal("");

--- a/search/src/components/OrgFilePageView.tsx
+++ b/search/src/components/OrgFilePageView.tsx
@@ -22,7 +22,7 @@ export interface FileUserPageViewProps {
 }
 
 export const OrgFileViewPage = (props: FileUserPageViewProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const [loading, setLoading] = createSignal(true);
   const [fileAndGroupIds, setFileAndGroupIds] = createSignal<FileAndGroupId[]>(

--- a/search/src/components/OrgGroupPageView.tsx
+++ b/search/src/components/OrgGroupPageView.tsx
@@ -18,7 +18,7 @@ export interface GroupUserPageViewProps {
 }
 
 export const GroupUserPageView = (props: GroupUserPageViewProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const [groups, setGroups] = createSignal<ChunkGroupDTO[]>([]);
   const [groupPage, setGroupPage] = createSignal(1);

--- a/search/src/components/RegisterOrUserProfile.tsx
+++ b/search/src/components/RegisterOrUserProfile.tsx
@@ -15,7 +15,7 @@ import { currentUser, isLoadingUser } from "../stores/userStore";
 import { currentDataset } from "../stores/datasetStore";
 
 const RegisterOrUserProfile = () => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
 
   const $dataset = useStore(currentDataset);
   const $currentUser = useStore(currentUser);

--- a/search/src/components/ResultsPage.tsx
+++ b/search/src/components/ResultsPage.tsx
@@ -47,7 +47,7 @@ export interface ResultsPageProps {
 }
 
 const ResultsPage = (props: ResultsPageProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
 
   const [chunkCollections, setChunkCollections] = createSignal<ChunkGroupDTO[]>(

--- a/search/src/components/ScoreChunk.tsx
+++ b/search/src/components/ScoreChunk.tsx
@@ -86,7 +86,7 @@ export interface ScoreChunkProps {
 const ScoreChunk = (props: ScoreChunkProps) => {
   const $currentDataset = useStore(currentDataset);
   const $currentUser = useStore(currentUser);
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $envs = useStore(clientConfig);
 
   const frontMatterValsToHide = $envs().FRONTMATTER_VALS?.split(",");

--- a/search/src/components/SingleChunkPage.tsx
+++ b/search/src/components/SingleChunkPage.tsx
@@ -24,7 +24,7 @@ export interface SingleChunkPageProps {
   defaultResultChunk: SingleChunkDTO;
 }
 export const SingleChunkPage = (props: SingleChunkPageProps) => {
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
   const initialChunkMetadata = props.defaultResultChunk.metadata;
 

--- a/search/src/components/SuggestedQueries.tsx
+++ b/search/src/components/SuggestedQueries.tsx
@@ -5,7 +5,7 @@ import { currentDataset } from "../stores/datasetStore";
 export const SuggestedQueries = (props: { query: string }) => {
   const [suggestedQueries, setSuggestedQueries] = createSignal<string[]>([]);
   const [authed, setAuthed] = createSignal<boolean>(true);
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const $dataset = useStore(currentDataset);
 
   createEffect(() => {

--- a/search/src/components/UploadFile.tsx
+++ b/search/src/components/UploadFile.tsx
@@ -6,7 +6,7 @@ import { currentDataset } from "../stores/datasetStore";
 
 export const UploadFile = () => {
   const $dataset = useStore(currentDataset);
-  const apiHost = import.meta.env.VITE_API_HOST as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as string;
   const [file, setFile] = createSignal<File | undefined>();
   const [link, setLink] = createSignal("");
   const [tagSet, setTagSet] = createSignal("");

--- a/search/src/stores/envsStore.ts
+++ b/search/src/stores/envsStore.ts
@@ -5,7 +5,7 @@ import {
 } from "../../utils/apiTypes";
 import { currentDataset } from "./datasetStore";
 
-const apiHost = import.meta.env.VITE_API_HOST as unknown as string;
+const apiHost = window.API_HOST || import.meta.env.VITE_API_HOST as unknown as string;
 
 const tryParse = (encoded: string) => {
   try {

--- a/search/src/stores/userStore.ts
+++ b/search/src/stores/userStore.ts
@@ -3,7 +3,7 @@ import { UserDTO, isUserDTO } from "../../utils/apiTypes";
 import { persistentAtom } from "@nanostores/persistent";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const apiHost: string = import.meta.env.VITE_API_HOST;
+const apiHost: string = window.API_HOST || import.meta.env.VITE_API_HOST;
 
 export const isLoadingUser = atom<boolean>(true);
 export const currentUser = persistentAtom("currentUser", null, {

--- a/search/src/vite-env.d.ts
+++ b/search/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  API_HOST?: string;
+}


### PR DESCRIPTION
@skeptrunedev 
Here's one way of doing what we wanted without rebuilding with vite on a user's machine

it exposes variables by setting them in the window object and using them with an or in solid

node:18 does the building
nginx:1.25.4-alpine-slim is the runtime

The multi-stage build gets rid of node dependencies and extra steps.

The runetime container is 12.3MB with 1.2kb of it being the dist code 

## Note

needs nginx config and redirect rules
Not sure of behavior if VITE environment variables are also specified