### PR TITLE
Dashboard Container

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:18 as build
+
+WORKDIR /app
+
+COPY package*.json ./
+
+COPY . .
+
+RUN yarn install
+RUN yarn run build
+
+FROM nginx:1.25.4-alpine-slim
+
+WORKDIR /usr/share/nginx/html
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+COPY <<'EOF' /etc/nginx/conf.d/default.conf
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+EOF
+
+COPY <<'EOF' /docker-entrypoint.d/01-insert-window-variable.sh
+#!/bin/sh
+
+set -eu
+
+cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.template
+envsubst < /usr/share/nginx/html/index.html.template > /usr/share/nginx/html/index.html 
+rm /usr/share/nginx/html/index.html.template
+
+EOF
+
+RUN chmod +x /docker-entrypoint.d/01-insert-window-variable.sh
+
+EXPOSE 80

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,7 +15,8 @@
     "@solidjs/router": "^0.10.1",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.8.11",
-    "terracotta": "^1.0.3"
+    "terracotta": "^1.0.3",
+    "vite-plugin-runtime-env": "^0.1.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -3,6 +3,7 @@ import solid from "vite-plugin-solid";
 import md from "vite-plugin-solid-markdown";
 import remarkGfm from "remark-gfm";
 import rehypePrettyCode from "rehype-pretty-code";
+import runtimeEnv from 'vite-plugin-runtime-env';
 
 export default defineConfig({
   plugins: [
@@ -24,5 +25,6 @@ export default defineConfig({
     solid({
       extensions: [".mdx", ".md"],
     }),
+    runtimeEnv(),
   ],
 });

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -492,7 +492,7 @@
   resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -2579,6 +2579,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+magic-string@^0.30.0:
+  version "0.30.8"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"
+  integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
 markdown-extensions@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
@@ -4657,6 +4664,13 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     unist-util-stringify-position "^4.0.0"
     vfile-message "^4.0.0"
+
+vite-plugin-runtime-env@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-runtime-env/-/vite-plugin-runtime-env-0.1.1.tgz#70f396f915d0859611c5a7a04ccfcdbd53aa76ba"
+  integrity sha512-xm7aw/BV2o6avLi1UCR9mIG+KZVv2UQhoqb4gUIxhiP7hkiLCYnG3aTFLYrHb8CmAzXkTvBRb63yOnAgJWYbgA==
+  dependencies:
+    magic-string "^0.30.0"
 
 vite-plugin-solid-markdown@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Add dashboard nginx container with runtime variable setting docker-entrypoint.
Add vite runtime env configuration plugin[vite-plugin-runtime-env](https://www.npmjs.com/package/vite-plugin-environment)
 
This allows us to do variable substitution in the index.html at runtime.
 
