### PR TITLE
faeture: attempts at more reliable queue

### DIFF
--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -333,6 +333,7 @@ pub struct IngestSpecificChunkMetadata {
     pub id: uuid::Uuid,
     pub qdrant_point_id: Option<uuid::Uuid>,
     pub dataset_id: uuid::Uuid,
+    pub attempt_number: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Selectable, Insertable, Clone)]

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -360,7 +360,7 @@ pub async fn create_chunk(
         .filter_map(|msg| serde_json::to_string(&msg).ok())
         .collect();
 
-    let pos_in_queue = redis::cmd("lpush")
+    let pos_in_queue = redis::cmd("rpush")
         .arg("ingestion")
         .arg(&serialized_messages)
         .query_async(&mut *redis_conn)
@@ -646,7 +646,7 @@ pub async fn update_chunk(
         .await
         .map_err(|err| ServiceError::BadRequest(err.to_string()))?;
 
-    redis::cmd("lpush")
+    redis::cmd("rpush")
         .arg("ingestion")
         .arg(serde_json::to_string(&message)?)
         .query_async(&mut *redis_conn)
@@ -787,7 +787,7 @@ pub async fn update_chunk_by_tracking_id(
         .await
         .map_err(|err| ServiceError::BadRequest(err.to_string()))?;
 
-    redis::cmd("lpush")
+    redis::cmd("rpush")
         .arg("ingestion")
         .arg(serde_json::to_string(&message)?)
         .query_async(&mut *redis_conn)

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -338,6 +338,7 @@ pub async fn create_chunk(
                 id: chunk_metadata.id,
                 qdrant_point_id: chunk_metadata.qdrant_point_id,
                 dataset_id: count_dataset_id,
+                attempt_number: 0
             },
             chunk: chunk_only_group_ids.clone(),
             dataset_id: count_dataset_id,

--- a/server/src/operators/qdrant_operator.rs
+++ b/server/src/operators/qdrant_operator.rs
@@ -250,7 +250,7 @@ pub async fn create_new_qdrant_point_query(
     splade_vector: Vec<(u32, f32)>,
     group_ids: Option<Vec<uuid::Uuid>>,
     config: ServerDatasetConfiguration,
-) -> Result<(), actix_web::Error> {
+) -> Result<(), ServiceError> {
     let qdrant_collection = config.QDRANT_COLLECTION_NAME;
 
     let qdrant = get_qdrant_connection(Some(&config.QDRANT_URL), Some(&config.QDRANT_API_KEY))


### PR DESCRIPTION
Attempts at making the queue implementation more reliable. 
Main changes:
- Use blpoprpush to put chunks into a processing queue
- Remove chunks from processing queue after processing is completed
- If a chunk remains in the queue for a long time, that ingestion service died, and needs to be restarted
- Implement a retry mechanism 3 times

This only works for `create_chunk` 
- if the `upsert_by_tracking_id` is marked as true. It won't revert the write to pg if qdrant errors. 