### PR TITLE
feature: allow for group_size to be 0 for group_search and group reccomendations

### DIFF
--- a/server/src/operators/qdrant_operator.rs
+++ b/server/src/operators/qdrant_operator.rs
@@ -953,7 +953,11 @@ pub async fn recommend_qdrant_groups_query(
         timeout: None,
         shard_key_selector: None,
         group_by: "group_ids".to_string(),
-        group_size,
+        group_size: if group_size == 0 {
+            1
+        } else {
+            group_size
+        },
         with_lookup: None,
     };
 
@@ -991,7 +995,11 @@ pub async fn recommend_qdrant_groups_query(
                 })
                 .collect();
 
-            Some(GroupSearchResults { group_id, hits })
+            if group_size == 0 {
+                Some(GroupSearchResults { group_id, hits: vec![] })
+            } else {
+                Some(GroupSearchResults { group_id, hits })
+            }
         })
         .collect();
     Ok(recommended_point_ids)

--- a/server/src/operators/qdrant_operator.rs
+++ b/server/src/operators/qdrant_operator.rs
@@ -650,7 +650,11 @@ pub async fn search_over_groups_query(
                     with_payload: None,
                     filter: Some(filter),
                     group_by: "group_ids".to_string(),
-                    group_size,
+                    group_size: if group_size == 0 {
+                        1
+                    } else {
+                        group_size
+                    },
                     ..Default::default()
                 })
                 .await
@@ -669,7 +673,11 @@ pub async fn search_over_groups_query(
                     with_payload: None,
                     filter: Some(filter),
                     group_by: "group_ids".to_string(),
-                    group_size,
+                    group_size: if group_size == 0 {
+                        1
+                    } else {
+                        group_size
+                    },
                     ..Default::default()
                 })
                 .await
@@ -707,7 +715,11 @@ pub async fn search_over_groups_query(
                 })
                 .collect();
 
-            Some(GroupSearchResults { group_id, hits })
+            if group_size == 0 {
+                Some(GroupSearchResults { group_id, hits: vec![] })
+            } else {
+                Some(GroupSearchResults { group_id, hits })
+            }
         })
         .collect();
 


### PR DESCRIPTION
Somewhat similar to https://github.com/devflowinc/trieve/pull/1185 but this time allowing for a group_size of 0 so that no content is returned also