### PR TITLE
ops: set buildcache to a dedicated buildcache repo, make the Dockerhub look cleaner

### DIFF
--- a/.github/workflows/chat-tests.yml
+++ b/.github/workflows/chat-tests.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths:
     - 'chat/**'
-    - '.github/workflows/**'
 
 jobs:
   build-test:

--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=trieve/server:buildcache-no-ocr
-          cache-to: type=registry,ref=trieve/server:buildcache-no-ocr,mode=max
+          cache-from: type=registry,ref=trieve/build-cache:no-ocr
+          cache-to: type=registry,ref=trieve/buildcache:no-ocr,mode=max
           context: server/
           file: ./server/Dockerfile.no-ocr
           push: true
@@ -75,8 +75,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=trieve/ingest:buildcache
-          cache-to: type=registry,ref=trieve/ingest:buildcache,mode=max
+          cache-from: type=registry,ref=trieve/buildcache:ingest
+          cache-to: type=registry,ref=trieve/buildcache:ingest,mode=max
           context: server/
           file: ./server/Dockerfile.microservice
           push: true
@@ -112,8 +112,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=trieve/server:buildcache-ocr
-          cache-to: type=registry,ref=trieve/server:buildcache-ocr,mode=max
+          cache-from: type=registry,ref=trieve/buildcache:ocr
+          cache-to: type=registry,ref=trieve/buildcache:ocr,mode=max
           context: server/
           file: ./server/Dockerfile.ocr
           push: true


### PR DESCRIPTION
- **feature: fix CI action from triggering docker push**
- **ops: set buildcache to a dedicated buildcache repo, make the Dockerhub look cleaner**

## Please indicate what issue this PR is related to and @ any maintainers who are relevant
