### PR TITLE
wip: bulk upload as default

### DIFF
--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -322,9 +322,9 @@ impl ChunkMetadata {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IngestSpecificChunkMetadata {
     pub id: uuid::Uuid,
-    pub qdrant_point_id: Option<uuid::Uuid>,
+    pub dataset_config: ServerDatasetConfiguration,
     pub dataset_id: uuid::Uuid,
-    pub attempt_number: usize,
+    pub qdrant_point_id: Option<uuid::Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Selectable, Insertable, Clone)]
@@ -1063,8 +1063,8 @@ pub enum EventType {
         file_id: uuid::Uuid,
         error: String,
     },
-    ChunkUploaded {
-        chunk_id: uuid::Uuid,
+    ChunksUploaded {
+        chunk_ids: Vec<uuid::Uuid>,
     },
     ChunkActionFailed {
         chunk_id: uuid::Uuid,
@@ -1080,7 +1080,7 @@ impl EventType {
         match self {
             EventType::FileUploaded { .. } => "file_uploaded".to_string(),
             EventType::FileUploadFailed { .. } => "file_upload_failed".to_string(),
-            EventType::ChunkUploaded { .. } => "chunk_uploaded".to_string(),
+            EventType::ChunksUploaded { .. } => "chunks_uploaded".to_string(),
             EventType::ChunkActionFailed { .. } => "chunk_action_failed".to_string(),
             EventType::ChunkUpdated { .. } => "chunk_updated".to_string(),
         }
@@ -1105,7 +1105,7 @@ impl From<EventType> for serde_json::Value {
             EventType::FileUploadFailed { file_id, error } => {
                 json!({"file_id": file_id, "error": error})
             }
-            EventType::ChunkUploaded { chunk_id } => json!({"chunk_id": chunk_id}),
+            EventType::ChunksUploaded { chunk_ids } => json!({"chunk_ids": chunk_ids}),
             EventType::ChunkActionFailed { chunk_id, error } => {
                 json!({"chunk_id": chunk_id, "error": error})
             }

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -155,6 +155,14 @@ pub struct UploadIngestionMessage {
     pub upsert_by_tracking_id: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BulkUploadIngestionMessage {
+    pub attempt_number: usize,
+    pub dataset_id: uuid::Uuid,
+    pub dataset_configuration: ServerDatasetConfiguration,
+    pub ingestion_messages: Vec<UploadIngestionMessage>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[schema(example = json!({
     "chunk_html": "<p>Some HTML content</p>",
@@ -212,8 +220,6 @@ pub enum CreateChunkData {
     Single(CreateSingleChunkData),
     Batch(CreateBatchChunkData),
 }
-
-
 
 /// Create or Upsert Chunk or Chunks
 ///
@@ -277,7 +283,7 @@ pub async fn create_chunk(
 
     timer.add("got redis connection");
 
-    let ingestion_messages = create_chunk_metadata(
+    let (ingestion_message, chunk_metadatas) = create_chunk_metadata(
         chunks,
         dataset_org_plan_sub.dataset.id,
         server_dataset_configuration,
@@ -285,23 +291,20 @@ pub async fn create_chunk(
     )
     .await?;
 
-    let serialized_messages: Vec<String> = ingestion_messages
-        .0
-        .iter()
-        .filter_map(|msg| serde_json::to_string(&msg).ok())
-        .collect();
+    let serialized_message: String = serde_json::to_string(&ingestion_message).map_err(|_| {
+        ServiceError::BadRequest("Failed to Serialize BulkUploadMessage".to_string())
+    })?;
 
     let pos_in_queue = redis::cmd("rpush")
         .arg("ingestion")
-        .arg(&serialized_messages)
+        .arg(&serialized_message)
         .query_async(&mut *redis_conn)
         .await
         .map_err(|err| ServiceError::BadRequest(err.to_string()))?;
 
     let response = match create_chunk_data.into_inner() {
         CreateChunkData::Single(_) => ReturnQueuedChunk::Single(SingleQueuedChunkResponse {
-            chunk_metadata: ingestion_messages
-            .1
+            chunk_metadata: chunk_metadatas
                 .get(0)
                 .ok_or(ServiceError::BadRequest(
                     "Failed to queue a single chunk due to deriving 0 ingestion_messages from the request data".to_string(),
@@ -310,7 +313,7 @@ pub async fn create_chunk(
             pos_in_queue,
         }),
         CreateChunkData::Batch(_) => ReturnQueuedChunk::Batch(BatchQueuedChunkResponse {
-            chunk_metadata: ingestion_messages.1,
+            chunk_metadata: chunk_metadatas,
             pos_in_queue,
         }),
     };

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -434,7 +434,6 @@ pub async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(oidc_client.clone()))
             .app_data(web::Data::new(redis_pool.clone()))
             .wrap(af_middleware::auth_middleware::AuthMiddlewareFactory)
-            .wrap(sentry_actix::Sentry::new())
             .wrap(
                 IdentityMiddleware::builder()
                     .login_deadline(Some(std::time::Duration::from_secs(SECONDS_IN_DAY)))
@@ -464,6 +463,7 @@ pub async fn main() -> std::io::Result<()> {
                 .cookie_path("/".to_owned())
                 .build(),
             )
+            .wrap(sentry_actix::Sentry::new())
             // enable logger
             .wrap(middleware::Logger::default())
             .service(Redoc::with_url("/redoc", ApiDoc::openapi()))


### PR DESCRIPTION
The issue with this PR is that PostgreSQL `tracking_id` conflict will instantly hault all other operations within a bulk_upload.
This likely will need to have a way so that it bulk inserts / bulk reverts PostgreSQL transactions. Not sure the implications as
far as writting duplicate_tracking_id events would look like from that though.

Very unsure about this PR, will review more in the morning