### PR TITLE
fix: remove SENTRY_URL from .env.server

### DIFF
--- a/.env.server
+++ b/.env.server
@@ -36,5 +36,4 @@ RERANKER_SERVER_ORIGIN=""
 BASE_SERVER_URL="http://localhost:8090"
 UNLIMITED="true"
 REDIS_CONNECTIONS=30
-SENTRY_URL="http://********************.ingest.sentry.io/******",
 QUANTIZE_VECTORS="false"


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
