### PR TITLE
feature: support for custom JINA_CODE_API_KEY

### DIFF
--- a/.env.server
+++ b/.env.server
@@ -38,3 +38,4 @@ UNLIMITED="true"
 REDIS_CONNECTIONS=30
 SENTRY_URL="http://********************.ingest.sentry.io/******",
 QUANTIZE_VECTORS="false"
+JINA_CODE_API_KEY=""


### PR DESCRIPTION
JINA_CODE does not work in text embedding inference https://github.com/huggingface/text-embeddings-inference/issues/270 and the previous embedding server PR does not scale #1487. Just going to use JINA_CLOUD internally. 