### PR TITLE
RUST_LOG has been added to the docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
       - RERANKER_SERVER_ORIGIN=${RERANKER_SERVER_ORIGIN}
       - UNLIMITED=${UNLIMITED}
       - REDIS_CONNECTIONS=${REDIS_CONNECTIONS}
+      - RUST_LOG=${RUST_LOG}
 
   ingestion-worker:
     image: trieve/ingest


### PR DESCRIPTION
RUST_LOG has been added to the docker-compose.yml file, because without it the variable only works when the server is hosted on a local machine outside the docker
@skeptrunedev 
#1551 