### PR TITLE
feature: improved JSON deserialization error message output

### DIFF
--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -31,6 +31,9 @@ pub enum ServiceError {
 
     #[display(fmt = "Not Found")]
     NotFound(String),
+
+    #[display(fmt = "Json Deserialization Error: {_0}")]
+    JsonDeserializeError(String),
 }
 
 // impl ResponseError trait allows to convert our errors into http responses with appropriate data
@@ -61,6 +64,11 @@ impl ResponseError for ServiceError {
             ServiceError::NotFound(ref message) => {
                 HttpResponse::NotFound().json(ErrorResponseBody {
                     message: format!("Not Found: {}", message),
+                })
+            }
+            ServiceError::JsonDeserializeError(ref message) => {
+                HttpResponse::BadRequest().json(ErrorResponseBody {
+                    message: format!("Json Deserialization Error: {}", message),
                 })
             }
         }

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -1479,9 +1479,8 @@ pub struct GetTrackingChunksData {
     tag = "chunk",
     request_body(content = GetTrackingChunksData, description = "JSON request payload to get the chunks in the request", content_type = "application/json"),
     responses(
-        (status = 200, description = "chunk with the id that you were searching for", body = Vec<ChunkMetadataStringTagSet>),
-        (status = 400, description = "Service error relating to fidning a chunk by tracking_id", body = ErrorResponseBody),
-        (status = 404, description = "Any one of the specified chunks not found", body = ErrorResponseBody)
+        (status = 200, description = "Chunks with one the ids which were specified", body = Vec<ChunkMetadataStringTagSet>),
+        (status = 400, description = "Service error relating to finding a chunk by tracking_id", body = ErrorResponseBody),
     ),
     params(
         ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),


### PR DESCRIPTION
Improves the error message for JSON payload deserialization. 

Updated format for the JSON deserialization error message: 

`"{message":"Json deserialization error: *Type* : Data error in JSON | *Message* : Json deserialize error: data did not match any variant of untagged enum CreateChunkReqPayloadEnum | Ensure that the data in the JSON payload is valid and consistent with the expected schema."}`