### PR TITLE
Added `num_value` as a default filter on search UI

### DIFF
--- a/chat/src/components/ScoreChunk.tsx
+++ b/chat/src/components/ScoreChunk.tsx
@@ -166,7 +166,23 @@ const ScoreChunk = (props: ScoreChunkProps) => {
               </span>
             </div>
           </Show>
-          <Show when={props.chunk.location}>
+          <Show when={props.chunk.num_value}>
+            <div class="flex gap-x-2">
+              <span class="font-semibold text-neutral-800 dark:text-neutral-200">
+                Num Value:{" "}
+              </span>
+              <span class="line-clamp-1 break-all">
+                {props.chunk.num_value}
+              </span>
+            </div>
+          </Show>
+          <Show
+            when={
+              props.chunk.location &&
+              props.chunk.location.lat &&
+              props.chunk.location.lon
+            }
+          >
             <div class="flex space-x-2">
               <span class="font-semibold text-neutral-800 dark:text-neutral-200">
                 Location:{" "}

--- a/chat/src/utils/apiTypes.ts
+++ b/chat/src/utils/apiTypes.ts
@@ -16,6 +16,7 @@ export interface ChunkMetadata {
     lat: number;
     lon: number;
   } | null;
+  num_value: number | null;
 }
 
 export const indirectHasOwnProperty = (obj: unknown, prop: string): boolean => {

--- a/search/src/components/ChunkMetadataDisplay.tsx
+++ b/search/src/components/ChunkMetadataDisplay.tsx
@@ -347,10 +347,29 @@ const ChunkMetadataDisplay = (props: ChunkMetadataDisplayProps) => {
               </Show>
               <Show
                 when={
+                  props.chunk.num_value &&
+                  !$envs()
+                    .FRONTMATTER_VALS?.split(",")
+                    ?.find((val) => val == "num_value")
+                }
+              >
+                <div class="flex gap-x-2">
+                  <span class="font-semibold text-neutral-800 dark:text-neutral-200">
+                    Num Value:{" "}
+                  </span>
+                  <span class="line-clamp-1 break-all">
+                    {props.chunk.num_value}
+                  </span>
+                </div>
+              </Show>
+              <Show
+                when={
                   props.chunk.location != null &&
                   !$envs()
                     .FRONTMATTER_VALS?.split(",")
-                    ?.find((val) => val == "location")
+                    ?.find((val) => val == "location") &&
+                  props.chunk.location.lat &&
+                  props.chunk.location.lon
                 }
               >
                 <div class="flex space-x-2">

--- a/search/src/components/CreateNewDocChunkForm.tsx
+++ b/search/src/components/CreateNewDocChunkForm.tsx
@@ -16,18 +16,25 @@ export const CreateNewDocChunkForm = () => {
   const datasetAndUserContext = useContext(DatasetAndUserContext);
 
   const $dataset = datasetAndUserContext.currentDataset;
-  const [docChunkLink, setDocChunkLink] = createSignal("");
-  const [tagSet, setTagSet] = createSignal("");
-  const [weight, setWeight] = createSignal(1);
-  const [locationLat, setLocationLat] = createSignal(0);
-  const [locationLon, setLocationLon] = createSignal(0);
+  const [docChunkLink, setDocChunkLink] = createSignal<string | undefined>(
+    undefined,
+  );
+  const [tagSet, setTagSet] = createSignal<string | undefined>(undefined);
+  const [weight, setWeight] = createSignal<number | undefined>(undefined);
+  const [locationLat, setLocationLat] = createSignal<number | undefined>(
+    undefined,
+  );
+  const [locationLon, setLocationLon] = createSignal<number | undefined>(
+    undefined,
+  );
+  const [numValue, setNumValue] = createSignal<number | undefined>(undefined);
   const [errorText, setErrorText] = createSignal<
     string | number | boolean | Node | JSX.ArrayElement | null | undefined
   >("");
   const [errorFields, setErrorFields] = createSignal<string[]>([]);
   const [isSubmitting, setIsSubmitting] = createSignal(false);
   const [showNeedLoginModal, setShowNeedLoginModal] = createSignal(false);
-  const [timestamp, setTimestamp] = createSignal("");
+  const [timestamp, setTimestamp] = createSignal<string | undefined>(undefined);
 
   const [editorHtmlContent, setEditorHtmlContent] = createSignal("");
   const [editorTextContent, setEditorTextContent] = createSignal("");
@@ -39,8 +46,6 @@ export const CreateNewDocChunkForm = () => {
 
     const chunkHTMLContentValue = editorHtmlContent();
     const chunkTextContentValue = editorTextContent();
-
-    const docChunkLinkValue = docChunkLink();
 
     if (chunkTextContentValue == "") {
       const errors: string[] = [];
@@ -57,14 +62,22 @@ export const CreateNewDocChunkForm = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requestBody: any = {
       chunk_html: chunkHTMLContentValue,
-      link: docChunkLinkValue,
-      tag_set: tagSet().split(","),
+      link: docChunkLink(),
+      tag_set: tagSet()?.split(","),
       weight: weight(),
-      location: {
+      num_value: numValue(),
+    };
+
+    if (locationLat() && locationLon()) {
+      requestBody.location = {
         lat: locationLat(),
         lon: locationLon(),
-      },
-    };
+      };
+    }
+
+    if (numValue()) {
+      requestBody.num_value = numValue();
+    }
 
     if (timestamp()) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -114,7 +127,8 @@ export const CreateNewDocChunkForm = () => {
           <div>Link to document chunk</div>
           <input
             type="url"
-            value={docChunkLink()}
+            placeholder="optional - link to the document chunk for convenience"
+            value={docChunkLink() ?? ""}
             onInput={(e) => setDocChunkLink(e.target.value)}
             classList={{
               "w-full bg-neutral-100 border border-gray-300 rounded-md px-4 py-1 dark:bg-neutral-700":
@@ -125,8 +139,8 @@ export const CreateNewDocChunkForm = () => {
           <div>Tag Set</div>
           <input
             type="text"
-            placeholder="optional - separate with commas"
-            value={tagSet()}
+            placeholder="optional - comma separated tags for optimized filtering"
+            value={tagSet() ?? ""}
             onInput={(e) => setTagSet(e.target.value)}
             class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
           />
@@ -134,18 +148,50 @@ export const CreateNewDocChunkForm = () => {
           <input
             type="date"
             class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
+            placeholder="optional - date of the document chunk for filtering"
+            value={timestamp() ?? ""}
             onInput={(e) => {
               setTimestamp(e.currentTarget.value);
             }}
           />
-          <div>Location Latitude and Longitude</div>
+          <div class="flex items-center gap-x-2">
+            <div>Number Value</div>
+            <div class="h-4.5 w-4.5 rounded-full border border-black dark:border-white">
+              <Tooltip
+                body={
+                  <BiRegularQuestionMark class="h-4 w-4 rounded-full fill-current" />
+                }
+                tooltipText="Optional. If you have a number value for this chunk, enter it here. This may be price, quantity, or any other numerical value."
+              />
+            </div>
+          </div>
+          <input
+            type="number"
+            value={numValue()}
+            placeholder="optional - price, quantity, or some other numeric for filtering"
+            onInput={(e) => setNumValue(Number(e.currentTarget.value))}
+            class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
+          />
+          <div class="flex items-center gap-x-2">
+            <div>Location (Lat, Lon)</div>
+            <div class="h-4.5 w-4.5 rounded-full border border-black dark:border-white">
+              <Tooltip
+                body={
+                  <BiRegularQuestionMark class="h-4 w-4 rounded-full fill-current" />
+                }
+                tooltipText="Optional. This is a coordinate value."
+              />
+            </div>
+          </div>
           <div class="flex space-x-2">
             <input
               type="number"
               step="0.00000001"
               placeholder="Latitude"
               value={locationLat()}
-              onInput={(e) => setLocationLat(Number(e.currentTarget.value))}
+              onInput={(e) =>
+                setLocationLat(() => Number(e.currentTarget.value))
+              }
               class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
             />
             <input
@@ -157,10 +203,21 @@ export const CreateNewDocChunkForm = () => {
               class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
             />
           </div>
-          <div>Weight for Merchandise Tuning</div>
+          <div class="flex items-center gap-x-2">
+            <div>Weight</div>
+            <div class="h-4.5 w-4.5 rounded-full border border-black dark:border-white">
+              <Tooltip
+                body={
+                  <BiRegularQuestionMark class="h-4 w-4 rounded-full fill-current" />
+                }
+                tooltipText="Optional. Weight is applied as a linear factor to score on search results. If you have something likeclickthrough data, you can use it to incrementally increase the boost of a chunk."
+              />
+            </div>
+          </div>
           <input
             type="number"
             step="0.000001"
+            placeholder="optional - weight is applied as linear boost to score for search"
             value={weight()}
             onInput={(e) => setWeight(Number(e.currentTarget.value))}
             class="w-full rounded-md border border-gray-300 bg-neutral-100 px-4 py-1 dark:bg-neutral-700"
@@ -202,7 +259,7 @@ export const CreateNewDocChunkForm = () => {
           setIsOpen={setShowNeedLoginModal}
         >
           <div class="min-w-[250px] sm:min-w-[300px]">
-            <BiRegularXCircle class="mx-auto h-8 w-8 fill-current  !text-red-500" />
+            <BiRegularXCircle class="mx-auto h-8 w-8 fill-current !text-red-500" />
             <div class="mb-4 text-center text-xl font-bold">
               Cannot add document chunk without an account
             </div>

--- a/search/src/components/FilterModal.tsx
+++ b/search/src/components/FilterModal.tsx
@@ -374,7 +374,16 @@ export const FilterItem = (props: FilterItemProps) => {
               : tempFilterField()
           }
         >
-          <For each={["tag_set", "link", "time_stamp", "location", "metadata"]}>
+          <For
+            each={[
+              "tag_set",
+              "link",
+              "time_stamp",
+              "location",
+              "metadata",
+              "num_value",
+            ]}
+          >
             {(filter_field) => {
               return (
                 <option

--- a/search/src/components/ScoreChunk.tsx
+++ b/search/src/components/ScoreChunk.tsx
@@ -528,10 +528,29 @@ const ScoreChunk = (props: ScoreChunkProps) => {
               </Show>
               <Show
                 when={
+                  props.chunk.num_value &&
+                  !$envs()
+                    .FRONTMATTER_VALS?.split(",")
+                    ?.find((val) => val == "num_value")
+                }
+              >
+                <div class="flex gap-x-2">
+                  <span class="font-semibold text-neutral-800 dark:text-neutral-200">
+                    Num Value:{" "}
+                  </span>
+                  <span class="line-clamp-1 break-all">
+                    {props.chunk.num_value}
+                  </span>
+                </div>
+              </Show>
+              <Show
+                when={
                   props.chunk.location &&
                   !$envs()
                     .FRONTMATTER_VALS?.split(",")
-                    ?.find((val) => val == "location")
+                    ?.find((val) => val == "location") &&
+                  props.chunk.location.lat &&
+                  props.chunk.location.lon
                 }
               >
                 <div class="flex space-x-2">

--- a/search/utils/apiTypes.ts
+++ b/search/utils/apiTypes.ts
@@ -18,6 +18,7 @@ export interface ChunkMetadata {
     lat: number;
     lon: number;
   } | null;
+  num_value: number | null;
   image_urls: string[] | null;
 }
 
@@ -40,6 +41,7 @@ export interface ChunkMetadataWithScore {
   } | null;
   score: number;
   image_urls: string[] | null;
+  num_value: number | null;
 }
 
 export const indirectHasOwnProperty = (obj: unknown, prop: string): boolean => {

--- a/search/yarn.lock
+++ b/search/yarn.lock
@@ -1091,9 +1091,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
-  version "1.0.30001636"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz"
-  integrity sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==
+  version "1.0.30001576"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
+  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -2834,16 +2834,8 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2888,14 +2880,7 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/search/yarn.lock
+++ b/search/yarn.lock
@@ -1091,9 +1091,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
-  version "1.0.30001576"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
-  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
+  version "1.0.30001636"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz"
+  integrity sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -2834,8 +2834,16 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2880,7 +2888,14 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/server/src/operators/search_operator.rs
+++ b/server/src/operators/search_operator.rs
@@ -345,10 +345,16 @@ pub async fn get_num_value_filter_condition(
                 MatchCondition::Float(id_val) => {
                     query = query.filter(chunk_metadata_columns::num_value.eq(*id_val));
                 }
-                MatchCondition::Text(_) => {
-                    return Err(ServiceError::BadRequest(
-                        "Invalid match condition for num_value".to_string(),
-                    ));
+                MatchCondition::Text(text_val) => {
+                    for id_str in text_val.split(',').map(str::trim) {
+                        if let Ok(id_val) = id_str.parse::<f64>() {
+                            query = query.filter(chunk_metadata_columns::num_value.eq(id_val));
+                        } else {
+                            return Err(ServiceError::BadRequest(
+                                "Invalid text match condition for num_value".to_string(),
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -361,10 +367,16 @@ pub async fn get_num_value_filter_condition(
                 MatchCondition::Float(id_val) => {
                     query = query.or_filter(chunk_metadata_columns::num_value.eq(id_val));
                 }
-                MatchCondition::Text(_) => {
-                    return Err(ServiceError::BadRequest(
-                        "Invalid match condition for num_value".to_string(),
-                    ));
+                MatchCondition::Text(text_val) => {
+                    for id_str in text_val.split(',').map(str::trim) {
+                        if let Ok(id_val) = id_str.parse::<f64>() {
+                            query = query.or_filter(chunk_metadata_columns::num_value.eq(id_val));
+                        } else {
+                            return Err(ServiceError::BadRequest(
+                                "Invalid text match condition for num_value".to_string(),
+                            ));
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implemented and tested `num_value` as a default filter on search UI.
- Can also parse apart lists for the `match` filter mode.

![image](https://github.com/devflowinc/trieve/assets/74870683/b3a384f9-294e-4760-ada0-7acecd190bb5)

