### PR TITLE
bugfix: filter modal closing when clicking on a non-interactive element

### DIFF
--- a/search/src/components/SearchForm.tsx
+++ b/search/src/components/SearchForm.tsx
@@ -475,6 +475,7 @@ const SearchForm = (props: {
                   <Show when={isOpen()}>
                     <PopoverPanel
                       unmount={false}
+                      tabIndex={0}
                       class="absolute z-10 mt-2 h-fit w-[480px] rounded-md bg-neutral-200 p-1 shadow-lg dark:bg-neutral-700"
                     >
                       <div class="items flex flex-col space-y-1">

--- a/search/src/components/SearchForm.tsx
+++ b/search/src/components/SearchForm.tsx
@@ -363,6 +363,7 @@ const SearchForm = (props: {
                   </PopoverButton>
                   <Show when={isOpen()}>
                     <PopoverPanel
+                      tabIndex={0}
                       unmount={false}
                       class="absolute z-10 mt-2 h-fit w-fit rounded-md bg-neutral-200 p-1 shadow-lg dark:bg-neutral-700"
                     >


### PR DESCRIPTION
Clicking on an input or button no longer closes the filters modal.