### PR TITLE
enhancement: use future::join with multiple reranker calls

### DIFF
--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -752,8 +752,7 @@ pub async fn cross_encoder(
 
                 let cur_client = reqwest::Client::new();
                 let embedding_api_key = get_env!("OPENAI_API_KEY", "OPENAI_API should be set");
-                let url = embedding_base_url.clone();
-
+                let url = embedding_server_call.clone();
                 let vectors_resp = async move {
                     let embeddings_resp = cur_client
                         .post(&url)

--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -707,8 +707,6 @@ pub async fn cross_encoder(
 
     let mut results = results.clone();
 
-    let reqwest_client = reqwest::Client::new();
-
     if request_docs.len() <= 20 {
         let resp = ureq::post(&embedding_server_call)
             .set("Content-Type", "application/json")
@@ -752,9 +750,9 @@ pub async fn cross_encoder(
                     truncate: true,
                 };
 
-                let cur_client = reqwest_client.clone();
+                let cur_client = reqwest::Client::new();
                 let embedding_api_key = get_env!("OPENAI_API_KEY", "OPENAI_API should be set");
-                let url = embedding_server_call.clone();
+                let url = embedding_base_url.clone();
 
                 let vectors_resp = async move {
                     let embeddings_resp = cur_client

--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -770,10 +770,7 @@ pub async fn cross_encoder(
                 async move {
                     let embeddings_resp = cur_client
                         .post(&url)
-                        .header(
-                            "Authorization",
-                            &format!("Bearer {}", &embedding_api_key),
-                        )
+                        .header("Authorization", &format!("Bearer {}", &embedding_api_key))
                         .header("api-key", &embedding_api_key.to_string())
                         .header("Content-Type", "application/json")
                         .json(&parameters)


### PR DESCRIPTION
- Uses `ureq` if there are fewer than 20 `request_docs`
- Creates async reqwest calls using `futures::join` if there are more than 20 `request_docs`
