### PR TITLE
feature: add qdrant_sync script to cleanup search index and OLTP data

### DIFF
--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -307,3 +307,52 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+
+  sync_qdrant:
+    name: Push Sync Qdrant script
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [blacksmith-8vcpu-ubuntu-2204]
+        platform: [linux/amd64]
+        exclude:
+          - runner: blacksmith-8vcpu-ubuntu-2204
+            platform: linux/arm64
+          - runner: blacksmith-8vcpu-ubuntu-2204-arm
+            platform: linux/amd64
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            trieve/sync_qdrant
+          tags: |
+            type=raw,latest
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=trieve/buildcache:sync_qdrant-${{matrix.runner}}
+          cache-to: type=registry,ref=trieve/buildcache:sync_qdrant-${{matrix.runner}},mode=max
+          context: server/
+          file: ./server/Dockerfile.sync-qdrant
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/search/src/components/ScoreChunk.tsx
+++ b/search/src/components/ScoreChunk.tsx
@@ -77,7 +77,6 @@ export interface ScoreChunkProps {
 
 const ScoreChunk = (props: ScoreChunkProps) => {
   const datasetAndUserContext = useContext(DatasetAndUserContext);
-  console.log(props.chunk);
 
   const $currentDataset = datasetAndUserContext.currentDataset;
   const $currentUser = datasetAndUserContext.user;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,6 +41,9 @@ path = "src/bin/redoc_ci.rs"
 name = "create-new-qdrant"
 path = "src/bin/create-new-qdrant.rs"
 
+[[bin]]
+name = "sync-qdrant"
+path = "src/bin/sync-qdrant.rs"
 
 [dependencies]
 actix-identity = { version = "0.7.1" }

--- a/server/Dockerfile.sync-qdrant
+++ b/server/Dockerfile.sync-qdrant
@@ -1,0 +1,28 @@
+FROM rust:1.75-slim-bookworm AS chef
+# We only pay the installation cost once, 
+# it will be cached from the second build onwards
+RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev g++ curl
+RUN cargo install cargo-chef 
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --features "runtime-env" --bin "sync-qdrant"
+
+FROM debian:bookworm-slim as runtime
+RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev ca-certificates 
+WORKDIR /app
+COPY ./migrations/ /app/migrations
+COPY --from=builder /app/target/release/sync-qdrant /app/sync-qdrant
+
+
+EXPOSE 8090
+ENTRYPOINT ["/app/sync-qdrant"]

--- a/server/src/bin/sync-qdrant.rs
+++ b/server/src/bin/sync-qdrant.rs
@@ -1,0 +1,73 @@
+use diesel_async::pooled_connection::{AsyncDieselConnectionManager, ManagerConfig};
+use trieve_server::{
+    errors::ServiceError,
+    establish_connection, get_env,
+    operators::{
+        chunk_operator::get_pg_point_ids_from_qdrant_point_ids,
+        qdrant_operator::{
+            delete_points_from_qdrant, get_qdrant_collections, scroll_qdrant_collection_ids,
+        },
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), ServiceError> {
+    dotenvy::dotenv().ok();
+
+    let database_url = get_env!("DATABASE_URL", "DATABASE_URL is not set");
+
+    let mut config = ManagerConfig::default();
+    config.custom_setup = Box::new(establish_connection);
+
+    let mgr = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new_with_config(
+        database_url,
+        config,
+    );
+
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(mgr)
+        .max_size(10)
+        .build()
+        .expect("Failed to create diesel_async pool");
+
+    let web_pool = actix_web::web::Data::new(pool.clone());
+
+    let collections = get_qdrant_collections().await?;
+
+    for collection in collections {
+        println!("starting on collection: {:?}", collection);
+
+        let mut offset = Some(uuid::Uuid::nil().to_string());
+
+        while let Some(cur_offset) = offset {
+            let (qdrant_point_ids, new_offset) = scroll_qdrant_collection_ids(
+                collection.clone(),
+                Some(cur_offset.to_string()),
+                Some(1000),
+            )
+            .await?;
+
+            let pg_point_ids =
+                get_pg_point_ids_from_qdrant_point_ids(qdrant_point_ids.clone(), web_pool.clone())
+                    .await?;
+
+            let qdrant_point_ids_not_in_pg = qdrant_point_ids
+                .iter()
+                .filter(|x| !pg_point_ids.contains(x))
+                .cloned()
+                .collect::<Vec<uuid::Uuid>>();
+
+            if qdrant_point_ids_not_in_pg.len() > 0 {
+                println!(
+                    "len of qdrant_point_ids_not_in_pg: {:?}",
+                    qdrant_point_ids_not_in_pg.len()
+                );
+
+                delete_points_from_qdrant(qdrant_point_ids_not_in_pg, collection.clone()).await?;
+            }
+
+            offset = new_offset;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- **feature: add new sync-qdrant script + cleanup: explicitly ignore payload and vector in qdrant search + cleanup: fix delete worker logs**
- **feature: add sync-qdrant Dockerfile and yaml**
