### PR TITLE
ops: reduce log spam by ignoring `/`, `/api/health` and `/metrics`. Bearer Auth only on `/metrics route`

### DIFF
--- a/server/src/bin/ingestion-worker.rs
+++ b/server/src/bin/ingestion-worker.rs
@@ -58,7 +58,7 @@ fn main() {
         tracing_subscriber::Registry::default()
             .with(sentry::integrations::tracing::layer())
             .with(
-                tracing_subscriber::fmt::layer().with_filter(
+                tracing_subscriber::fmt::layer().without_time().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),
@@ -70,7 +70,7 @@ fn main() {
     } else {
         tracing_subscriber::Registry::default()
             .with(
-                tracing_subscriber::fmt::layer().with_filter(
+                tracing_subscriber::fmt::layer().without_time().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),

--- a/server/src/handlers/metrics_handler.rs
+++ b/server/src/handlers/metrics_handler.rs
@@ -137,7 +137,8 @@ fn check_x_api_access(req: &actix_web::HttpRequest) -> bool {
         }
 
         if let Some(api_key) = auth_api_key {
-            return api_key.to_str().unwrap_or_default() == admin_key.as_str();
+            return format!("Bearer: {}", api_key.to_str().unwrap_or_default()).as_str()
+                == admin_key.as_str();
         }
     }
 


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
