### PR TITLE
bugfix: allow Shift+Enter to create new lines in the edit prompt textarea

### DIFF
--- a/frontends/chat/src/components/Atoms/AfMessage.tsx
+++ b/frontends/chat/src/components/Atoms/AfMessage.tsx
@@ -214,7 +214,7 @@ export const AfMessage = (props: AfMessageProps) => {
                         if (e.key === "Escape") {
                           setEditing(false);
                         }
-                        if (e.key === "Enter") {
+                        if (e.key === "Enter" && !e.shiftKey) {
                           e.preventDefault();
                           props.onEdit(editingMessageContent());
                           setEditedContent(editingMessageContent());


### PR DESCRIPTION
Shift+Enter creates new lines rather than submitting the chat query when editing message.