### PR TITLE
feature: add route to organization for updating the ServerConfiguration of all datasets

### DIFF
--- a/server/src/bin/delete-worker.rs
+++ b/server/src/bin/delete-worker.rs
@@ -8,7 +8,7 @@ use std::sync::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use trieve_server::{
-    data::models::{self, ServerDatasetConfiguration},
+    data::models::{self, DatasetConfiguration},
     errors::ServiceError,
     establish_connection, get_env,
     operators::{
@@ -235,7 +235,7 @@ async fn delete_worker(
                 continue;
             }
         };
-        let server_config = ServerDatasetConfiguration::from_json(dataset.server_configuration);
+        let dataset_config = DatasetConfiguration::from_json(dataset.server_configuration);
 
         if delete_worker_message.empty_dataset {
             log::info!("Cleaning dataset {:?}", delete_worker_message.dataset_id);
@@ -243,7 +243,7 @@ async fn delete_worker(
                 delete_worker_message.dataset_id,
                 web_pool.clone(),
                 clickhouse_client.clone(),
-                server_config.clone(),
+                dataset_config.clone(),
             )
             .await
             {
@@ -291,7 +291,7 @@ async fn delete_worker(
             delete_worker_message.dataset_id,
             web_pool.clone(),
             clickhouse_client.clone(),
-            server_config.clone(),
+            dataset_config.clone(),
         )
         .await
         {

--- a/server/src/bin/grupdate-worker.rs
+++ b/server/src/bin/grupdate-worker.rs
@@ -16,7 +16,7 @@ use trieve_server::{
     },
 };
 use trieve_server::{
-    data::models::{Event, ServerDatasetConfiguration},
+    data::models::{DatasetConfiguration, Event},
     operators::dataset_operator::get_dataset_by_id_query,
 };
 
@@ -236,7 +236,7 @@ async fn grupdate_worker(
                 continue;
             }
         };
-        let service_config = ServerDatasetConfiguration::from_json(dataset.server_configuration);
+        let service_config = DatasetConfiguration::from_json(dataset.server_configuration);
 
         match update_grouped_chunks_query(
             group_update_msg.prev_group.clone(),

--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -1,8 +1,8 @@
 use super::auth_handler::{AdminOnly, LoggedUser};
 use crate::{
     data::models::{
-        DatasetAndOrgWithSubAndPlan, File, FileAndGroupId, FileWorkerMessage, Pool, RedisPool,
-        ServerDatasetConfiguration,
+        DatasetAndOrgWithSubAndPlan, DatasetConfiguration, File, FileAndGroupId, FileWorkerMessage,
+        Pool, RedisPool,
     },
     errors::ServiceError,
     middleware::auth_middleware::verify_member,
@@ -352,14 +352,13 @@ pub async fn delete_file_handler(
     _user: AdminOnly,
     dataset_org_plan_sub: DatasetAndOrgWithSubAndPlan,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let server_dataset_config = ServerDatasetConfiguration::from_json(
-        dataset_org_plan_sub.dataset.server_configuration.clone(),
-    );
+    let dataset_config =
+        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration.clone());
     delete_file_query(
         file_id.into_inner(),
         dataset_org_plan_sub.dataset,
         pool,
-        server_dataset_config,
+        dataset_config,
     )
     .await?;
 

--- a/server/src/handlers/topic_handler.rs
+++ b/server/src/handlers/topic_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data::models::{DatasetAndOrgWithSubAndPlan, Pool, ServerDatasetConfiguration, Topic},
+    data::models::{DatasetAndOrgWithSubAndPlan, DatasetConfiguration, Pool, Topic},
     errors::ServiceError,
     handlers::auth_handler::AdminOnly,
     operators::{
@@ -52,10 +52,9 @@ pub async fn create_topic(
     pool: web::Data<Pool>,
 ) -> Result<HttpResponse, actix_web::Error> {
     let data_inner = data.into_inner();
-    let default_model = ServerDatasetConfiguration::from_json(
-        dataset_org_plan_sub.dataset.server_configuration.clone(),
-    )
-    .LLM_DEFAULT_MODEL;
+    let default_model =
+        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration.clone())
+            .LLM_DEFAULT_MODEL;
 
     let first_message = data_inner.first_user_message;
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -140,7 +140,7 @@ impl Modify for SecurityAddon {
             name = "BSL",
             url = "https://github.com/devflowinc/trieve/blob/main/LICENSE.txt",
         ),
-        version = "0.11.0",
+        version = "0.11.1",
     ),
     servers(
         (url = "https://api.trieve.ai",
@@ -210,6 +210,7 @@ impl Modify for SecurityAddon {
         handlers::organization_handler::delete_organization,
         handlers::organization_handler::get_organization_usage,
         handlers::organization_handler::get_organization_users,
+        handlers::organization_handler::update_all_org_dataset_configs,
         handlers::dataset_handler::create_dataset,
         handlers::dataset_handler::update_dataset,
         handlers::dataset_handler::delete_dataset,
@@ -297,8 +298,9 @@ impl Modify for SecurityAddon {
             handlers::file_handler::UploadFileResult,
             handlers::invitation_handler::InvitationData,
             handlers::event_handler::GetEventsData,
-            handlers::organization_handler::CreateOrganizationData,
-            handlers::organization_handler::UpdateOrganizationData,
+            handlers::organization_handler::CreateOrganizationReqPayload,
+            handlers::organization_handler::UpdateOrganizationReqPayload,
+            handlers::organization_handler::UpdateAllOrgDatasetConfigsReqPayload,
             operators::event_operator::EventReturn,
             operators::search_operator::DeprecatedSearchOverGroupsResponseBody,
             operators::search_operator::GroupScoreChunk,
@@ -949,6 +951,10 @@ pub fn main() -> std::io::Result<()> {
                                         .route(web::get().to(
                                             handlers::organization_handler::get_organization_users,
                                         )),
+                                )
+                                .service(
+                                    web::resource("/update_dataset_configs")
+                                        .route(web::post().to(handlers::organization_handler::update_all_org_dataset_configs)),
                                 )
                                 .service(
                                     web::resource("/{organization_id}/user/{user_id}")

--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::data::models::{
     ChunkData, ChunkGroupBookmark, ChunkMetadataTable, ChunkMetadataTags, ChunkMetadataTypes,
-    ContentChunkMetadata, Dataset, DatasetTags, IngestSpecificChunkMetadata,
-    ServerDatasetConfiguration, SlimChunkMetadata, SlimChunkMetadataTable, UnifiedId,
+    ContentChunkMetadata, Dataset, DatasetConfiguration, DatasetTags, IngestSpecificChunkMetadata,
+    SlimChunkMetadata, SlimChunkMetadataTable, UnifiedId,
 };
 use crate::get_env;
 use crate::handlers::chunk_handler::UploadIngestionMessage;
@@ -1187,7 +1187,7 @@ pub async fn delete_chunk_metadata_query(
     chunk_uuid: Vec<uuid::Uuid>,
     dataset: Dataset,
     pool: web::Data<Pool>,
-    config: ServerDatasetConfiguration,
+    dataset_config: DatasetConfiguration,
 ) -> Result<(), ServiceError> {
     let chunk_metadata =
         get_metadata_from_ids_query(chunk_uuid.clone(), dataset.id, pool.clone()).await?;
@@ -1227,7 +1227,7 @@ pub async fn delete_chunk_metadata_query(
         })
         .await;
 
-    let qdrant_collection = format!("{}_vectors", config.EMBEDDING_SIZE);
+    let qdrant_collection = format!("{}_vectors", dataset_config.EMBEDDING_SIZE);
 
     let qdrant_client = get_qdrant_connection(
         Some(get_env!("QDRANT_URL", "QDRANT_URL should be set")),
@@ -1548,7 +1548,7 @@ pub async fn get_row_count_for_organization_id_query(
 pub async fn create_chunk_metadata(
     chunks: Vec<ChunkReqPayload>,
     dataset_uuid: uuid::Uuid,
-    dataset_configuration: ServerDatasetConfiguration,
+    dataset_configuration: DatasetConfiguration,
     pool: web::Data<Pool>,
 ) -> Result<(BulkUploadIngestionMessage, Vec<ChunkMetadata>), ServiceError> {
     let mut ingestion_messages = vec![];

--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -6,9 +6,7 @@ use super::group_operator::{create_group_from_file_query, create_group_query};
 use super::parse_operator::{build_chunking_regex, coarse_doc_chunker, convert_html_to_text};
 use crate::data::models::ChunkGroup;
 use crate::data::models::FileDTO;
-use crate::data::models::{
-    Dataset, DatasetAndOrgWithSubAndPlan, EventType, ServerDatasetConfiguration,
-};
+use crate::data::models::{Dataset, DatasetAndOrgWithSubAndPlan, DatasetConfiguration, EventType};
 use crate::handlers::chunk_handler::ChunkReqPayload;
 use crate::handlers::file_handler::UploadFileReqPayload;
 use crate::{data::models::Event, get_env};
@@ -211,8 +209,8 @@ pub async fn create_file_chunks(
         ));
     }
 
-    let server_dataset_configuration =
-        ServerDatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration);
+    let dataset_config =
+        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration);
 
     let chunk_segments = chunks
         .chunks(120)
@@ -225,7 +223,7 @@ pub async fn create_file_chunks(
         let (ingestion_message, _) = create_chunk_metadata(
             chunk_segment,
             dataset_org_plan_sub.dataset.id,
-            server_dataset_configuration.clone(),
+            dataset_config.clone(),
             pool.clone(),
         )
         .await?;
@@ -352,7 +350,7 @@ pub async fn delete_file_query(
     file_uuid: uuid::Uuid,
     dataset: Dataset,
     pool: web::Data<Pool>,
-    config: ServerDatasetConfiguration,
+    dataset_config: DatasetConfiguration,
 ) -> Result<(), actix_web::Error> {
     use crate::data::schema::files::dsl as files_columns;
 

--- a/server/src/operators/message_operator.rs
+++ b/server/src/operators/message_operator.rs
@@ -1,6 +1,6 @@
 use crate::data::models::{
-    self, ChunkMetadataStringTagSet, ChunkMetadataTypes, Dataset, RagQueryEventClickhouse,
-    SearchMethod, ServerDatasetConfiguration,
+    self, ChunkMetadataStringTagSet, ChunkMetadataTypes, Dataset, DatasetConfiguration,
+    RagQueryEventClickhouse, SearchMethod,
 };
 use crate::diesel::prelude::*;
 use crate::get_env;
@@ -108,7 +108,7 @@ pub async fn create_generic_system_message(
 
 #[tracing::instrument(skip(pool))]
 pub async fn create_topic_message_query(
-    config: &ServerDatasetConfiguration,
+    config: &DatasetConfiguration,
     previous_messages: Vec<Message>,
     new_message: Message,
     dataset_id: uuid::Uuid,
@@ -226,11 +226,10 @@ pub async fn stream_response(
     dataset: Dataset,
     pool: web::Data<Pool>,
     clickhouse_client: web::Data<clickhouse::Client>,
-    config: ServerDatasetConfiguration,
+    dataset_config: DatasetConfiguration,
     create_message_req_payload: CreateMessageReqPayload,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let dataset_config =
-        ServerDatasetConfiguration::from_json(dataset.server_configuration.clone());
+    let dataset_config = DatasetConfiguration::from_json(dataset.server_configuration.clone());
 
     let user_message_query = match create_message_req_payload.concat_user_messages_query {
         Some(true) => messages
@@ -675,8 +674,7 @@ pub async fn get_topic_string(
         seed: None,
     };
 
-    let dataset_config =
-        ServerDatasetConfiguration::from_json(dataset.server_configuration.clone());
+    let dataset_config = DatasetConfiguration::from_json(dataset.server_configuration.clone());
     let base_url = dataset_config.LLM_BASE_URL;
 
     let base_url = if base_url.is_empty() {

--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data::models::{ChunkMetadataTypes, ScoreChunkDTO, ServerDatasetConfiguration},
+    data::models::{ChunkMetadataTypes, DatasetConfiguration, ScoreChunkDTO},
     errors::ServiceError,
     get_env,
     handlers::chunk_handler::{BoostPhrase, DistancePhrase},
@@ -30,7 +30,7 @@ pub async fn create_embedding(
     message: String,
     distance_phrase: Option<DistancePhrase>,
     embed_type: &str,
-    dataset_config: ServerDatasetConfiguration,
+    dataset_config: DatasetConfiguration,
 ) -> Result<Vec<f32>, ServiceError> {
     let parent_span = sentry::configure_scope(|scope| scope.get_span());
     let transaction: sentry::TransactionOrSpan = match &parent_span {
@@ -269,7 +269,7 @@ pub async fn get_sparse_vector(
 pub async fn create_embeddings(
     content_and_boosts: Vec<(String, Option<DistancePhrase>)>,
     embed_type: &str,
-    dataset_config: ServerDatasetConfiguration,
+    dataset_config: DatasetConfiguration,
     reqwest_client: reqwest::Client,
 ) -> Result<Vec<Vec<f32>>, ServiceError> {
     let parent_span = sentry::configure_scope(|scope| scope.get_span());
@@ -780,7 +780,7 @@ pub async fn cross_encoder(
     query: String,
     page_size: u64,
     results: Vec<ScoreChunkDTO>,
-    dataset_config: &ServerDatasetConfiguration,
+    dataset_config: &DatasetConfiguration,
 ) -> Result<Vec<ScoreChunkDTO>, actix_web::Error> {
     let parent_span = sentry::configure_scope(|scope| scope.get_span());
     let transaction: sentry::TransactionOrSpan = match &parent_span {


### PR DESCRIPTION
Also ships some nice doc updates for the dataset configs so it's easier to understand what you can set for the dataset config. 

Since removing the `ClientConfiguration` the `server` prefix was no longer needed, so also dropped that throughout the code base. Will figure out a migration for the table and dataset create/update routes later. 