### PR TITLE
cleanup: do not use quote and negated terms by default + documentation: add docs for TR-Dataset to specify a tracking_id can be used"

### DIFF
--- a/frontends/search/src/components/GroupPage.tsx
+++ b/frontends/search/src/components/GroupPage.tsx
@@ -213,6 +213,7 @@ export const GroupPage = (props: GroupPageProps) => {
             highlight_window: search.debounced.highlightWindow,
             recency_bias: search.debounced.recencyBias,
             use_reranker: search.debounced.useReranker,
+            use_quote_negated_terms: search.debounced.useQuoteNegatedTerms,
           }),
         }).then((response) => {
           if (response.ok) {

--- a/frontends/search/src/components/ResultsPage.tsx
+++ b/frontends/search/src/components/ResultsPage.tsx
@@ -196,6 +196,7 @@ const ResultsPage = (props: ResultsPageProps) => {
         highlight_window: props.search.debounced.highlightWindow ?? 0,
         group_size: props.search.debounced.group_size ?? 3,
         use_reranker: props.search.debounced.useReranker,
+        use_quote_negated_terms: props.search.debounced.useQuoteNegatedTerms,
       };
 
       let searchRoute = "chunk/search";

--- a/frontends/search/src/components/SearchForm.tsx
+++ b/frontends/search/src/components/SearchForm.tsx
@@ -683,6 +683,22 @@ const SearchForm = (props: { search: SearchStore; groupID?: string }) => {
                           />
                         </div>
                         <div class="flex items-center justify-between space-x-2 p-1">
+                          <label>Use Quote Negated Words</label>
+                          <input
+                            class="h-4 w-4"
+                            type="checkbox"
+                            checked={tempSearchValues().useQuoteNegatedTerms}
+                            onChange={(e) => {
+                              setTempSearchValues((prev) => {
+                                return {
+                                  ...prev,
+                                  useQuoteNegatedTerms: e.target.checked,
+                                };
+                              });
+                            }}
+                          />
+                        </div>
+                        <div class="flex items-center justify-between space-x-2 p-1">
                           <label>Get Total Pages (Latency Penalty):</label>
                           <input
                             class="h-4 w-4"

--- a/frontends/search/src/hooks/useSearch.ts
+++ b/frontends/search/src/hooks/useSearch.ts
@@ -20,6 +20,7 @@ const initalState = {
   highlightWindow: 0,
   group_size: 3,
   useReranker: false,
+  useQuoteNegatedTerms: false,
 };
 
 export type SearchOptions = typeof initalState;
@@ -43,6 +44,7 @@ const fromStateToParams = (state: SearchOptions): Params => {
     highlightWindow: state.highlightWindow.toString(),
     group_size: state.group_size?.toString(),
     useReranker: state.useReranker.toString(),
+    useQuoteNegatedTerms: state.useQuoteNegatedTerms.toString(),
   };
 };
 
@@ -67,6 +69,7 @@ const fromParamsToState = (
     highlightWindow: parseInt(params.highlightWindow ?? "0"),
     group_size: parseInt(params.group_size ?? "3"),
     useReranker: (params.useReranker ?? "false") === "true",
+    useQuoteNegatedTerms: (params.useQuoteNegatedTerms ?? "false") === "true",
   };
 };
 

--- a/server/src/handlers/analytics_handler.rs
+++ b/server/src/handlers/analytics_handler.rs
@@ -25,7 +25,7 @@ use actix_web::{web, HttpResponse};
         (status = 400, description = "Service error relating to getting cluster analytics", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -79,7 +79,7 @@ pub async fn get_cluster_analytics(
         (status = 400, description = "Service error relating to getting search analytics", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -231,7 +231,7 @@ pub async fn get_search_analytics(
         (status = 400, description = "Service error relating to getting RAG analytics", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -292,7 +292,7 @@ pub async fn get_rag_analytics(
         (status = 400, description = "Service error relating to getting recommendation analytics", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -276,7 +276,7 @@ pub enum CreateChunkReqPayloadEnum {
         (status = 400, description = "Error typically due to deserialization issues", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -440,7 +440,7 @@ pub async fn create_chunk(
         (status = 400, description = "Service error relating to finding a chunk by tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("chunk_id" = Option<uuid::Uuid>, Path, description = "Id of the chunk you want to fetch."),
     ),
     security(
@@ -483,7 +483,7 @@ pub async fn delete_chunk(
         (status = 400, description = "Service error relating to finding a chunk by tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = Option<String>, Path, description = "tracking_id of the chunk you want to delete"),
     ),
     security(
@@ -585,7 +585,7 @@ pub struct UpdateIngestionMessage {
         (status = 400, description = "Service error relating to to updating chunk, likely due to conflicting tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -746,7 +746,7 @@ pub struct UpdateChunkByTrackingIdData {
         (status = 400, description = "Service error relating to to updating chunk", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -1105,7 +1105,7 @@ pub fn parse_query(query: String) -> ParsedQuery {
         (status = 400, description = "Service error relating to searching", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1384,7 +1384,7 @@ impl From<AutocompleteReqPayload> for SearchChunksReqPayload {
         (status = 400, description = "Service error relating to searching", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1521,7 +1521,7 @@ pub enum ChunkReturnTypes {
         (status = 404, description = "Chunk not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise."),
         ("chunk_id" = Option<uuid::Uuid>, Path, description = "Id of the chunk you want to fetch."),
     ),
@@ -1595,7 +1595,7 @@ pub struct CountChunkQueryResponseBody {
         (status = 404, description = "Failed to count chunks", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),
@@ -1715,7 +1715,7 @@ pub async fn count_chunks(
         (status = 404, description = "Chunk not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise."),
         ("tracking_id" = Option<String>, Path, description = "tracking_id of the chunk you want to fetch"),
     ),
@@ -1776,7 +1776,7 @@ pub struct GetChunksData {
         (status = 404, description = "Any one of the specified chunks not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1848,7 +1848,7 @@ pub struct GetTrackingChunksData {
         (status = 400, description = "Service error relating to finding a chunk by tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1952,7 +1952,7 @@ pub enum RecommendResponseTypes {
         (status = 400, description = "Service error relating to to getting similar chunks", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -2265,7 +2265,7 @@ pub struct GenerateChunksRequest {
         (status = 400, description = "Service error relating to to updating chunk, likely due to conflicting tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),

--- a/server/src/handlers/dataset_handler.rs
+++ b/server/src/handlers/dataset_handler.rs
@@ -76,7 +76,7 @@ pub struct CreateDatasetRequest {
     pub dataset_name: String,
     /// Organization ID that the dataset will belong to.
     pub organization_id: uuid::Uuid,
-    /// Optional tracking ID for the dataset. Can be used to track the dataset in external systems. Must be unique within the organization.
+    /// Optional tracking ID for the dataset. Can be used to track the dataset in external systems. Must be unique within the organization. Strongly recommended to not use a valid uuid value as that will not work with the TR-Dataset header.
     pub tracking_id: Option<String>,
     /// The configuration of the dataset. See the example request payload for the potential keys which can be set. It is possible to break your dataset's functionality by erroneously setting this field. We recommend setting through creating a dataset at dashboard.trieve.ai and managing it's settings there.
     pub server_configuration: Option<serde_json::Value>,
@@ -171,19 +171,19 @@ pub async fn create_dataset(
 pub struct UpdateDatasetRequest {
     /// The id of the dataset you want to update.
     pub dataset_id: Option<uuid::Uuid>,
-    /// tracking ID for the dataset. Can be used to track the dataset in external systems.
+    /// The tracking ID of the dataset you want to update.
     pub tracking_id: Option<String>,
     /// The new name of the dataset. Must be unique within the organization. If not provided, the name will not be updated.
     pub dataset_name: Option<String>,
     /// The configuration of the dataset. See the example request payload for the potential keys which can be set. It is possible to break your dataset's functionality by erroneously updating this field. We recommend updating through the settings panel for your dataset at dashboard.trieve.ai.
     pub server_configuration: Option<serde_json::Value>,
-    /// Optional new tracking ID for the dataset. Can be used to track the dataset in external systems. Must be unique within the organization. If not provided, the tracking ID will not be updated.
+    /// Optional new tracking ID for the dataset. Can be used to track the dataset in external systems. Must be unique within the organization. If not provided, the tracking ID will not be updated. Strongly recommended to not use a valid uuid value as that will not work with the TR-Dataset header.
     pub new_tracking_id: Option<String>,
 }
 
 /// Update Dataset
 ///
-/// Update a dataset. The auth'ed user must be an owner of the organization to update a dataset.
+/// Update a dataset by id or tracking_id. One of id or tracking_id must be provided. The auth'ed user must be an owner of the organization to update a dataset.
 #[utoipa::path(
     put,
     path = "/dataset",
@@ -250,7 +250,7 @@ pub async fn update_dataset(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid, Path, description = "The id of the dataset you want to delete."),
 
     ),
@@ -296,7 +296,7 @@ pub async fn delete_dataset(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid, Path, description = "The id of the dataset you want to clear."),
 
     ),
@@ -339,7 +339,7 @@ pub async fn clear_dataset(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = String, Path, description = "The tracking id of the dataset you want to delete."),
     ),
     security(
@@ -385,7 +385,7 @@ pub async fn delete_dataset_by_tracking_id(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid, Path, description = "The id of the dataset you want to retrieve."),
     ),
     security(
@@ -424,7 +424,7 @@ pub async fn get_dataset(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid, Path, description = "The id of the dataset you want to retrieve usage for."),
     ),
     security(
@@ -458,7 +458,7 @@ pub async fn get_usage_by_dataset_id(
         (status = 404, description = "Dataset not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = String, Path, description = "The tracking id of the dataset you want to retrieve."),
     ),
     security(

--- a/server/src/handlers/event_handler.rs
+++ b/server/src/handlers/event_handler.rs
@@ -37,7 +37,7 @@ pub struct GetEventsData {
         (status = 400, description = "Service error relating to getting events for the dataset", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),

--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -104,7 +104,7 @@ pub struct UploadFileResult {
         (status = 400, description = "Service error relating to uploading the file", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -237,7 +237,7 @@ pub async fn upload_file_handler(
         (status = 404, description = "File not found", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("file_id" = uuid::Uuid, description = "The id of the file to fetch"),
     ),
     security(
@@ -280,7 +280,7 @@ pub struct FileData {
         (status = 400, description = "Service error relating to getting the files in the current datase", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid::Uuid, description = "The id of the dataset to fetch files for."),
         ("page" = u64, description = "The page number of files you wish to fetch. Each page contains at most 10 files."),
     ),
@@ -338,7 +338,7 @@ pub async fn get_dataset_files_handler(
         (status = 400, description = "Service error relating to finding or deleting the file", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("file_id" = uuid::Uuid, description = "The id of the file to delete"),
     ),
     security(

--- a/server/src/handlers/group_handler.rs
+++ b/server/src/handlers/group_handler.rs
@@ -86,7 +86,7 @@ pub struct CreateChunkGroupReqPayload {
         (status = 400, description = "Service error relating to creating the chunkGroup", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -150,7 +150,7 @@ pub struct DatasetGroupQuery {
         (status = 400, description = "Service error relating to getting the groups created by the given dataset", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("dataset_id" = uuid::Uuid, description = "The id of the dataset to fetch groups for."),
         ("page" = i64, description = "The page of groups to fetch. Page is 1-indexed."),
     ),
@@ -195,7 +195,7 @@ pub struct GetGroupByTrackingIDData {
         (status = 404, description = "Group not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = String, description = "The tracking id of the group to fetch."),
     ),
     security(
@@ -241,7 +241,7 @@ pub struct GetGroupData {
         (status = 404, description = "Group not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_id" = Option<uuid::Uuid>, Path, description = "Id of the group you want to fetch."),
     ),
     security(
@@ -294,7 +294,7 @@ pub struct UpdateGroupByTrackingIDReqPayload {
         (status = 400, description = "Service error relating to updating the chunkGroup", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = uuid::Uuid, description = "Tracking id of the chunk_group to update"),
     ),
     security(
@@ -355,7 +355,7 @@ pub struct DeleteGroupByTrackingIDData {
         (status = 400, description = "Service error relating to deleting the chunkGroup", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = uuid::Uuid, description = "Tracking id of the chunk_group to delete"),
         ("delete_chunks" = bool, Query, description = "Delete the chunks within the group"),
     ),
@@ -413,7 +413,7 @@ pub struct DeleteGroupData {
         (status = 400, description = "Service error relating to deleting the chunkGroup", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_id" = Option<uuid::Uuid>, Path, description = "Id of the group you want to fetch."),
         ("delete_chunks" = bool, Query, description = "Delete the chunks within the group"),
     ),
@@ -487,7 +487,7 @@ pub struct UpdateChunkGroupData {
         (status = 400, description = "Service error relating to updating the chunkGroup", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -578,7 +578,7 @@ pub struct AddChunkToGroupData {
         (status = 400, description = "Service error relating to getting the groups that the chunk is in.", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_id" = uuid, description = "Id of the group to add the chunk to as a bookmark"),
     ),
     security(
@@ -638,7 +638,7 @@ pub struct AddChunkToGroupByTrackingIdData {
         (status = 400, description = "Service error relating to getting the groups that the chunk is in.", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("tracking_id" = uuid, description = "Id of the group to add the chunk to as a bookmark"),
     ),
     security(
@@ -731,7 +731,7 @@ pub enum BookmarkGroupResponse {
         (status = 404, description = "Group not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_id" = uuid::Uuid, Path, description = "Id of the group you want to fetch."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The version of the API to use for the request"),
         ("page" = Option<u64>, description = "The page of chunks to get from the group"),
@@ -789,7 +789,7 @@ pub struct GetAllBookmarksByTrackingIdData {
         (status = 404, description = "Group not found", body = ErrorResponseBody)
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_tracking_id" = String, description = "The id of the group to get the chunks from"),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The version of the API to use for the request"),
         ("page" = u64, description = "The page of chunks to get from the group"),
@@ -848,7 +848,7 @@ pub struct GetGroupsForChunksData {
         (status = 400, description = "Service error relating to getting the groups that the chunk is in", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),
@@ -890,7 +890,7 @@ pub struct RemoveChunkFromGroupReqPayload {
         (status = 400, description = "Service error relating to removing the chunk from the group", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("group_id" = Option<uuid::Uuid>, Path, description = "Id of the group you want to remove the chunk from."),
     ),
     security(
@@ -980,7 +980,7 @@ pub enum RecommendGroupsResponse {
         (status = 400, description = "Service error relating to to getting similar chunks", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1324,7 +1324,7 @@ impl From<SearchWithinGroupResults> for SearchWithinGroupResponseBody {
         (status = 400, description = "Service error relating to getting the groups that the chunk is in", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(
@@ -1502,7 +1502,7 @@ pub struct SearchOverGroupsData {
         (status = 400, description = "Service error relating to searching over groups", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
     ),
     security(

--- a/server/src/handlers/message_handler.rs
+++ b/server/src/handlers/message_handler.rs
@@ -130,7 +130,7 @@ pub struct CreateMessageReqPayload {
         (status = 400, description = "Service error relating to getting a chat completion", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),
@@ -248,7 +248,7 @@ pub async fn create_message(
         (status = 400, description = "Service error relating to getting the messages", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("messages_topic_id" = uuid, description = "The ID of the topic to get messages for."),
     ),
     security(
@@ -412,7 +412,7 @@ impl From<RegenerateMessageReqPayload> for CreateMessageReqPayload {
         (status = 400, description = "Service error relating to getting a chat completion", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),
@@ -481,7 +481,7 @@ pub async fn edit_message(
         (status = 400, description = "Service error relating to getting a chat completion", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),
@@ -611,7 +611,7 @@ pub struct SuggestedQueriesResponse {
         (status = 400, description = "Service error relating to to updating chunk, likely due to conflicting tracking_id", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["readonly"]),

--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -328,6 +328,35 @@ pub async fn remove_user_from_org(
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[schema(example = json!({
+    "organization_id": "00000000-0000-0000-0000-000000000000",
+    "server_configuration": {
+        "LLM_BASE_URL": "https://api.openai.com/v1",
+        "EMBEDDING_BASE_URL": "https://api.openai.com/v1",
+        "EMBEDDING_MODEL_NAME": "text-embedding-3-small",
+        "MESSAGE_TO_QUERY_PROMPT": "Write a 1-2 sentence semantic search query along the lines of a hypothetical response to: \n\n",
+        "RAG_PROMPT": "Use the following retrieved documents in your response. Include footnotes in the format of the document number that you used for a sentence in square brackets at the end of the sentences like [^n] where n is the doc number. These are the docs:",
+        "N_RETRIEVALS_TO_INCLUDE": 8,
+        "EMBEDDING_SIZE": 1536,
+        "LLM_DEFAULT_MODEL": "gpt-3.5-turbo-1106",
+        "BM25_ENABLED": true,
+        "BM25_B": 0.75,
+        "BM25_K": 0.75,
+        "BM25_AVG_LEN": 256.0,
+        "FULLTEXT_ENABLED": true,
+        "SEMANTIC_ENABLED": true,
+        "EMBEDDING_QUERY_PREFIX": "",
+        "USE_MESSAGE_TO_QUERY_PROMPT": false,
+        "FREQUENCY_PENALTY": 0.0,
+        "TEMPERATURE": 0.5,
+        "PRESENCE_PENALTY": 0.0,
+        "STOP_TOKENS": ["\n\n", "\n"],
+        "INDEXED_ONLY": false,
+        "LOCKED": false,
+        "SYSTEM_PROMPT": "You are a helpful assistant",
+        "MAX_LIMIT": 10000
+    }
+}))]
 pub struct UpdateAllOrgDatasetConfigsReqPayload {
     /// The id of the organization to update the dataset configurations for.
     pub organization_id: uuid::Uuid,

--- a/server/src/handlers/topic_handler.rs
+++ b/server/src/handlers/topic_handler.rs
@@ -38,7 +38,7 @@ pub struct CreateTopicReqPayload {
         (status = 400, description = "Topic name empty or a service error", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -108,7 +108,7 @@ pub struct DeleteTopicData {
         (status = 400, description = "Service error relating to topic deletion", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
         ("topic_id" = uuid, Path, description = "The id of the topic you want to delete."),
     ),
     security(
@@ -151,7 +151,7 @@ pub struct UpdateTopicReqPayload {
         (status = 400, description = "Service error relating to topic update", body = ErrorResponseBody),
     ),
     params(
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),
@@ -191,7 +191,7 @@ pub async fn update_topic(
     ),
     params (
         ("owner_id", description="The owner_id to get topics of; A common approach is to use a browser fingerprint or your user's id"),
-        ("TR-Dataset" = String, Header, description = "The dataset id to use for the request"),
+        ("TR-Dataset" = String, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
     ),
     security(
         ("ApiKey" = ["admin"]),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -140,7 +140,7 @@ impl Modify for SecurityAddon {
             name = "BSL",
             url = "https://github.com/devflowinc/trieve/blob/main/LICENSE.txt",
         ),
-        version = "0.11.1",
+        version = "0.11.2",
     ),
     servers(
         (url = "https://api.trieve.ai",

--- a/server/src/operators/search_operator.rs
+++ b/server/src/operators/search_operator.rs
@@ -236,16 +236,16 @@ pub async fn assemble_qdrant_filter(
         }
     };
 
-    if quote_words.is_some() {
-        for quote_word in quote_words.unwrap() {
+    if let Some(quote_words) = quote_words {
+        for quote_word in quote_words {
             filter
                 .must
                 .push(Condition::matches_text("content", quote_word));
         }
     }
 
-    if negated_words.is_some() {
-        for negated_word in negated_words.unwrap() {
+    if let Some(negated_words) = negated_words {
+        for negated_word in negated_words {
             filter
                 .must_not
                 .push(Condition::matches_text("content", negated_word));


### PR DESCRIPTION
- **cleanup: do not use quote negated terms by default**
- **documentation: add docs to the TR-Dataset headers to note that we accept tracking_id's as valid values**
