### PR TITLE
observerability: add timestamp logs back to workers

### DIFF
--- a/server/src/bin/ingestion-worker.rs
+++ b/server/src/bin/ingestion-worker.rs
@@ -59,7 +59,7 @@ fn main() {
         tracing_subscriber::Registry::default()
             .with(sentry::integrations::tracing::layer())
             .with(
-                tracing_subscriber::fmt::layer().without_time().with_filter(
+                tracing_subscriber::fmt::layer().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),
@@ -71,7 +71,7 @@ fn main() {
     } else {
         tracing_subscriber::Registry::default()
             .with(
-                tracing_subscriber::fmt::layer().without_time().with_filter(
+                tracing_subscriber::fmt::layer().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),

--- a/server/src/bin/queue-bm25-migration.rs
+++ b/server/src/bin/queue-bm25-migration.rs
@@ -1,3 +1,4 @@
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use trieve_server::{
     data::models::{MigratePointMessage, MigrationMode},
     errors::ServiceError,
@@ -9,6 +10,14 @@ use trieve_server::{
 #[tokio::main]
 async fn main() -> Result<(), ServiceError> {
     dotenvy::dotenv().ok();
+    tracing_subscriber::Registry::default()
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::from_default_env()
+                    .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
+            ),
+        )
+        .init();
 
     let redis_url = get_env!("REDIS_URL", "REDIS_URL is not set");
     let redis_connections: u32 = std::env::var("REDIS_CONNECTIONS")
@@ -40,11 +49,11 @@ async fn main() -> Result<(), ServiceError> {
         .collect();
 
     for collection in collections {
-        println!("queue'ing collection: {:?}", collection);
+        log::info!("queue'ing collection: {:?}", collection);
 
         let mut offset = Some(uuid::Uuid::nil().to_string());
 
-        while let Some(cur_offset) = offset {
+        while let Some(cur_offset) = offset.clone() {
             let (qdrant_point_ids, new_offset) = scroll_qdrant_collection_ids(
                 collection.clone(),
                 Some(cur_offset.to_string()),
@@ -58,7 +67,7 @@ async fn main() -> Result<(), ServiceError> {
                 .expect("Failed to connect to redis");
 
             let message = serde_json::to_string(&MigratePointMessage {
-                qdrant_point_ids,
+                qdrant_point_ids: qdrant_point_ids.clone(),
                 from_collection: collection.clone(),
                 to_collection: format!("{}_bm25", collection),
                 mode: MigrationMode::BM25 {
@@ -78,6 +87,12 @@ async fn main() -> Result<(), ServiceError> {
                     ServiceError::BadRequest("Failed to send message to redis".to_string())
                 })?;
 
+            log::info!(
+                "Migrated {:?} points between {:?} and {:?}",
+                qdrant_point_ids.len(),
+                offset.clone(),
+                new_offset.clone()
+            );
             offset = new_offset;
         }
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -439,7 +439,7 @@ pub fn main() -> std::io::Result<()> {
         tracing_subscriber::Registry::default()
             .with(sentry::integrations::tracing::layer())
             .with(
-                tracing_subscriber::fmt::layer().without_time().with_filter(
+                tracing_subscriber::fmt::layer().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),
@@ -452,7 +452,7 @@ pub fn main() -> std::io::Result<()> {
     } else {
         tracing_subscriber::Registry::default()
             .with(
-                tracing_subscriber::fmt::layer().without_time().with_filter(
+                tracing_subscriber::fmt::layer().with_filter(
                     EnvFilter::from_default_env()
                         .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
                 ),


### PR DESCRIPTION
I thought excluding times was a good idea since we have a log sync solution with k9s, but k9s is not a good solution for logs with timestamps.

Adding back explicit timestamps for now
