### PR TITLE
Fix QDRANT API key environment variable and update Dockerfile path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   qdrant-database:
     image: qdrant/qdrant:v1.10.1
     environment:
-      - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}
+      - QDRANT_SERVICE_API_KEY=${QDRANT_API_KEY}
     ports:
       - 6333:6333
       - 6334:6334

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,7 +247,7 @@ services:
     image: trieve/search
     build:
       context: ./frontends
-      dockerfile: /search/
+      dockerfile: ./search/Dockerfile
     networks:
       - app-network
     ports:


### PR DESCRIPTION
## Changes in this PR:

1. Fixed the QDRANT API key environment variable:
   - Removed: `- QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}`
   - Added: `- QDRANT_SERVICE_API_KEY=${QDRANT_API_KEY}`

2. Updated the Dockerfile path for the search service:
   - Changed from: `dockerfile: /search/`
   - To: `dockerfile: ./search/Dockerfile`

## Rationale for changes:

1. The QDRANT API key environment variable was incorrectly formatted. This change ensures the correct variable name is used, allowing proper authentication with the QDRANT service.

2. The Dockerfile path has been updated to use a relative path and explicitly specify the Dockerfile. This change improves clarity and ensures the correct Dockerfile is used for the search service during build image container.