### PR TITLE
enhancement: disable no-unused-locals for ts

### DIFF
--- a/frontends/analytics/tsconfig.json
+++ b/frontends/analytics/tsconfig.json
@@ -1,6 +1,9 @@
 {
-  "extends": "config/tsconfig",
-  "include": [
-    "src",
-  ],
+	"extends": "config/tsconfig",
+	"compilerOptions": {
+		"noUnusedLocals": false
+	},
+	"include": [
+		"src"
+	]
 }

--- a/frontends/chat/tsconfig.json
+++ b/frontends/chat/tsconfig.json
@@ -1,6 +1,9 @@
 {
-  "extends": "config/tsconfig",
-  "include": [
-    "src",
-  ],
+	"extends": "config/tsconfig",
+	"compilerOptions": {
+		"noUnusedLocals": false
+	},
+	"include": [
+		"src"
+	]
 }

--- a/frontends/dashboard/tsconfig.json
+++ b/frontends/dashboard/tsconfig.json
@@ -1,6 +1,9 @@
 {
-  "extends": "config/tsconfig",
-  "include": [
-    "src",
-  ],
+	"extends": "config/tsconfig",
+	"compilerOptions": {
+		"noUnusedLocals": false
+	},
+	"include": [
+		"src"
+	]
 }

--- a/frontends/search/tsconfig.json
+++ b/frontends/search/tsconfig.json
@@ -1,6 +1,9 @@
 {
-  "extends": "config/tsconfig",
-  "include": [
-    "src",
-  ],
+	"extends": "config/tsconfig",
+	"compilerOptions": {
+		"noUnusedLocals": false
+	},
+	"include": [
+		"src"
+	]
 }

--- a/frontends/shared/tsconfig.json
+++ b/frontends/shared/tsconfig.json
@@ -1,10 +1,13 @@
 {
-  "extends": "config/tsconfig",
-  "include": [
-    "src",
-    "ui",
-    "types",
-    "types.ts",
-    "utils"
-  ],
+	"extends": "config/tsconfig",
+	"compilerOptions": {
+		"noUnusedLocals": false
+	},
+	"include": [
+		"src",
+		"ui",
+		"types",
+		"types.ts",
+		"utils"
+	],
 }


### PR DESCRIPTION
We need to disable no-unused-locals for typescript so that the _ prefix change for eslint makes sense