### PR TITLE
cleanup: allow floats for boostFactor in create and update pages of search playground"

### DIFF
--- a/frontends/search/src/components/CreateNewDocChunkForm.tsx
+++ b/frontends/search/src/components/CreateNewDocChunkForm.tsx
@@ -295,6 +295,7 @@ export const CreateNewDocChunkForm = () => {
             />
             <input
               type="number"
+              step="any"
               placeholder="optional - boost value to multiplicatevely increase presence of boost terms in IDF index"
               value={boostFactor()}
               onChange={(e) => setBoostFactor(Number(e.currentTarget.value))}

--- a/frontends/search/src/components/EditChunkPageForm.tsx
+++ b/frontends/search/src/components/EditChunkPageForm.tsx
@@ -402,6 +402,7 @@ export const EditChunkPageForm = (props: SingleChunkPageProps) => {
                   />
                   <input
                     type="number"
+                    step="any"
                     placeholder="optional - boost value to multiplicatevely increase presence of boost terms in IDF index"
                     value={boostFactor()}
                     onChange={(e) =>


### PR DESCRIPTION
- **bugfix: update ingestion message was borked by serde skip on serialize; now fixed**
- **cleanup: allow floats for boost factor**
