### PR TITLE
docs: update api endpoint of query suggestions

### DIFF
--- a/frontends/dashboard/src/components/Routes.ts
+++ b/frontends/dashboard/src/components/Routes.ts
@@ -18,7 +18,7 @@ export const ApiRoutes = {
     "PUT /api/chunk",
     "POST /api/chunk/autocomplete",
     "POST /api/chunk/count",
-    "POST /api/chunk/gen_suggestions",
+    "POST /api/chunk/suggestions",
     "POST /api/chunk/generate",
     "POST /api/chunk/recommend",
     "POST /api/chunk/search",

--- a/server/src/handlers/message_handler.rs
+++ b/server/src/handlers/message_handler.rs
@@ -723,7 +723,7 @@ pub struct SuggestedQueriesResponse {
 /// This endpoint will generate 3 suggested queries based off a hybrid search using RAG with the query provided in the request body and return them as a JSON object.
 #[utoipa::path(
     post,
-    path = "/chunk/gen_suggestions",
+    path = "/chunk/suggestions",
     context_path = "/api",
     tag = "Chunk",
     request_body(content = SuggestedQueriesReqPayload, description = "JSON request payload to get alternative suggested queries", content_type = "application/json"),


### PR DESCRIPTION
Api docs are currently wrong [here](https://docs.trieve.ai/api-reference/chunk/generate-suggested-queries), and it seems the open api json is also not updated [here](https://api.trieve.ai/api-docs/openapi.json) and this fixes the second part and the open API endpoint


cc @densumesh @skeptrunedev 