### PR TITLE
cleanup: remove unused feature flags in file_handler for ocr

### DIFF
--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -19,10 +19,6 @@ use base64::{
     engine::{self, general_purpose},
     Engine as _,
 };
-#[cfg(feature = "ocr")]
-use magick_rust::MagickWand;
-#[cfg(feature = "ocr")]
-use pyo3::{types::PyDict, Python};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 


### PR DESCRIPTION
These feature flags were not being used and causing clippy warnings 