### PR TITLE
cleanup: properly set docstrings for structs to match payloads for boost and distance phrase

### DIFF
--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -45,7 +45,7 @@ use simple_server_timing_header::Timer;
 use tokio_stream::StreamExt;
 use utoipa::ToSchema;
 
-/// Boost is useful for when you want to boost certain phrases in the fulltext search results for official listings. I.e. making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the AirBNB token for its official listing.
+/// Boost phrase is useful for when you want to boost certain phrases in the fulltext (SPLADE) and BM25 search results. I.e. making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the in-document-frequency of the AirBNB token (AKA word) for its official listing. Conceptually it multiples the in-document-importance second value in the tuples of the SPLADE or BM25 sparse vector of the chunk_html innerText for all tokens present in the boost phrase by the boost factor like so: (token, in-document-importance) -> (token, in-document-importance*boost_factor).
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct BoostPhrase {
     /// The phrase to boost in the fulltext document frequency index
@@ -54,7 +54,7 @@ pub struct BoostPhrase {
     pub boost_factor: f64,
 }
 
-/// Distance is useful for when you want to boost certain phrases in the fulltext search results for official listings. I.e. making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the AirBNB token for its official listing.
+/// Distance phrase is useful for moving the embedding vector of the chunk in the direction of the distance phrase. I.e. you can push a chunk with a chunk_html of "iphone" 25% closer to the term "flagship" by using the distance phrase "flagship" and a distance factor of 0.25. Conceptually it's drawing a line (euclidean/L2 distance) between the vector for the innerText of the chunk_html and distance_phrase then moving the vector of the chunk_html distance_factor*L2Distance closer to or away from the distance_phrase point along the line between the two points.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DistancePhrase {
     /// The phrase to boost in the fulltext document frequency index


### PR DESCRIPTION
When a struct is used in a payload, the docstring for that struct appears in the docs instead of the docstring for that key in the request payload. Due to this, the docs for distance phrase were off. This PR fixes that issue. There are other places in the docs where this same fix should eventually be applied. 
