### PR TITLE
bugfix: fix delete dataset in settings page

### DIFF
--- a/frontends/dashboard/src/pages/Dashboard/Dataset/DatasetSettingsPage.tsx
+++ b/frontends/dashboard/src/pages/Dashboard/Dataset/DatasetSettingsPage.tsx
@@ -754,16 +754,13 @@ export const DangerZoneForm = () => {
     if (!confirmBox) return;
 
     setDeleting(true);
-    fetch(`${import.meta.env.VITE_API_HOST}/dataset`, {
+    fetch(`${import.meta.env.VITE_API_HOST}/dataset/${dataset_id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        "TR-Organization": organization_id,
+        "TR-Dataset": dataset_id,
       },
       credentials: "include",
-      body: JSON.stringify({
-        dataset_id: dataset_id,
-      }),
     })
       .then((res) => {
         setDeleting(false);


### PR DESCRIPTION
This was using the old api method for deleting datasets, we have since deprecated the delete route with a json payload