### PR TITLE
feature: delete files and groups with clear route

### DIFF
--- a/frontends/chat/src/components/ScoreChunk.tsx
+++ b/frontends/chat/src/components/ScoreChunk.tsx
@@ -8,11 +8,10 @@ import {
   type ChunkMetadataWithVotes,
 } from "../utils/apiTypes";
 import { BiRegularChevronDown, BiRegularChevronUp } from "solid-icons/bi";
-import { VsFileSymlinkFile } from "solid-icons/vs";
 import sanitizeHtml from "sanitize-html";
 import { Tooltip } from "shared/ui";
 import { AiOutlineCopy } from "solid-icons/ai";
-import { FiCheck, FiGlobe } from "solid-icons/fi";
+import { FiCheck, FiExternalLink, FiGlobe } from "solid-icons/fi";
 
 export const sanitzerOptions = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -121,11 +120,11 @@ const ScoreChunk = (props: ScoreChunkProps) => {
             <FiCheck class="text-green-500" />
           </Show>
           <a
-            title="Open"
-            href={`${searchURL}/chunk/${props.chunk.id}`}
+            title="Open in Search Playground to edit or get recommendations"
+            href={`${searchURL}/chunk/${props.chunk.id}?dataset=${props.chunk.dataset_id}`}
             target="_blank"
           >
-            <VsFileSymlinkFile class="h-5 w-5 fill-current opacity-50" />
+            <FiExternalLink class="h-5 w-5 fill-current opacity-50" />
           </a>
         </div>
         <div class="flex w-full flex-col">

--- a/frontends/chat/src/utils/apiTypes.ts
+++ b/frontends/chat/src/utils/apiTypes.ts
@@ -17,6 +17,7 @@ export interface ChunkMetadata {
     lon: number;
   } | null;
   num_value: number | null;
+  dataset_id: string;
 }
 
 export const indirectHasOwnProperty = (obj: unknown, prop: string): boolean => {

--- a/frontends/dashboard/src/components/DatasetOverview.tsx
+++ b/frontends/dashboard/src/components/DatasetOverview.tsx
@@ -500,7 +500,7 @@ export const DatasetOverview = (props: DatasetOverviewProps) => {
                               <FiTrash />
                             </button>
                           }
-                          tooltipText="Delete Dataset - This will fully delete the dataset and make it no longer accessible. All chunks, groups, files , and the dataset itself will be fully removed."
+                          tooltipText="Delete Dataset - This will fully delete all chunks, groups, files, and the dataset itself."
                         />
                         <Tooltip
                           direction="left"
@@ -517,7 +517,7 @@ export const DatasetOverview = (props: DatasetOverviewProps) => {
                               <AiOutlineClear />
                             </button>
                           }
-                          tooltipText="Clear Dataset - This will remove all chunks from the dataset, but not groups, files, or the dataset itself."
+                          tooltipText="Clear Dataset - This will delete all chunks, groups, and files in the dataset, but not the analytics or dataset itself."
                         />
                       </td>
                     </tr>

--- a/frontends/dashboard/src/pages/Dashboard/Dataset/DatasetSettingsPage.tsx
+++ b/frontends/dashboard/src/pages/Dashboard/Dataset/DatasetSettingsPage.tsx
@@ -993,7 +993,7 @@ export const DatasetSettingsPage = () => {
     if (!datasetId) return;
 
     const modifiedFields = getModifiedFields();
-    console.log(modifiedFields);
+    const originalServerConfig = serverConfig();
 
     if (Object.keys(modifiedFields).length === 0) {
       createToast({
@@ -1023,7 +1023,7 @@ export const DatasetSettingsPage = () => {
             type: "success",
             message: "Dataset Configuration Saved",
           });
-          setOriginalConfig(serverConfig());
+          setOriginalConfig(originalServerConfig);
           if (modifiedFields.LLM_API_KEY) {
             setServerConfig((prev) => ({ ...prev, LLM_API_KEY: "" }));
           }

--- a/frontends/search/src/components/BookmarkPopover.tsx
+++ b/frontends/search/src/components/BookmarkPopover.tsx
@@ -21,9 +21,10 @@ import {
   type ChunkMetadata,
 } from "../utils/apiTypes";
 import InputRowsForm from "./Atoms/InputRowsForm";
-import { VsBookmark } from "solid-icons/vs";
 import { BiRegularChevronLeft, BiRegularChevronRight } from "solid-icons/bi";
 import { DatasetAndUserContext } from "./Contexts/DatasetAndUserContext";
+import { AiOutlineGroup } from "solid-icons/ai";
+import { Tooltip } from "shared/ui";
 
 export interface BookmarkPopoverProps {
   chunkMetadata: ChunkMetadata;
@@ -240,18 +241,23 @@ const BookmarkPopover = (props: BookmarkPopoverProps) => {
       {({ isOpen, setState }) => (
         <div>
           <div class="flex items-center">
-            <PopoverButton
-              title="Bookmark"
-              onClick={() => {
-                if (notLoggedIn() || $currentUser?.()?.id === undefined) {
-                  props.setLoginModal?.(true);
-                  return;
-                }
-                refetchBookmarks(localGroupPage());
-              }}
-            >
-              <VsBookmark class="z-0 h-5 w-5 fill-current" />
-            </PopoverButton>
+            <Tooltip
+              body={
+                <PopoverButton
+                  onClick={() => {
+                    if (notLoggedIn() || $currentUser?.()?.id === undefined) {
+                      props.setLoginModal?.(true);
+                      return;
+                    }
+                    refetchBookmarks(localGroupPage());
+                  }}
+                >
+                  <AiOutlineGroup class="z-0 h-5 w-5 fill-current" />
+                </PopoverButton>
+              }
+              tooltipText="Manage Groups For This Chunk"
+              direction="left"
+            />
           </div>
           <Show
             when={

--- a/frontends/search/src/components/ChunkMetadataDisplay.tsx
+++ b/frontends/search/src/components/ChunkMetadataDisplay.tsx
@@ -18,7 +18,7 @@ import {
 } from "../utils/apiTypes";
 import { BiRegularChevronDown, BiRegularChevronUp } from "solid-icons/bi";
 import sanitizeHtml from "sanitize-html";
-import { VsFileSymlinkFile } from "solid-icons/vs";
+import { FiEye } from "solid-icons/fi";
 import BookmarkPopover from "./BookmarkPopover";
 import { FiEdit, FiTrash } from "solid-icons/fi";
 import { formatDate, sanitzerOptions } from "./ScoreChunk";
@@ -148,15 +148,15 @@ const ChunkMetadataDisplay = (props: ChunkMetadataDisplayProps) => {
               <Tooltip
                 body={
                   <a
-                    title="Open"
+                    title="Open chunk to test recommendations for similar chunks"
                     href={`/chunk/${props.chunk.id}?dataset=${
                       $currentDataset?.()?.dataset.id ?? ""
                     }`}
                   >
-                    <VsFileSymlinkFile class="h-5 w-5 fill-current" />
+                    <FiEye class="h-5 w-5" />
                   </a>
                 }
-                tooltipText="Open in new tab"
+                tooltipText="Open to test recommendations for similar chunks"
               />
 
               <BookmarkPopover

--- a/frontends/search/src/components/GroupPage.tsx
+++ b/frontends/search/src/components/GroupPage.tsx
@@ -51,7 +51,7 @@ import { downloadFile } from "../utils/downloadFile";
 import ScoreChunk from "./ScoreChunk";
 import { BiRegularXCircle } from "solid-icons/bi";
 import { createToast } from "./ShowToasts";
-import { VsFileSymlinkFile } from "solid-icons/vs";
+import { FiEye } from "solid-icons/fi";
 
 export interface GroupPageProps {
   groupID: string;
@@ -594,11 +594,10 @@ export const GroupPage = (props: GroupPageProps) => {
               }}
             />
           </div>
-          <div class="mt-4 flex w-full max-w-screen-2xl justify-end">
+          <div class="mt-4 flex w-full max-w-screen-2xl justify-end gap-x-2">
             <button
               classList={{
-                "!pointer-events-auto relative max-h-10 mt-2 items-end justify-end rounded-md p-2 text-center bg-red-500":
-                  true,
+                "flex space-x-2 rounded bg-neutral-500 p-2 text-white": true,
                 "animate-pulse": fetchingGroups(),
               }}
               onClick={() => setEditing(false)}
@@ -607,8 +606,7 @@ export const GroupPage = (props: GroupPageProps) => {
             </button>
             <button
               classList={{
-                "!pointer-events-auto relative max-h-10 mt-2 items-end justify-end rounded-md p-2 text-center bg-green-500":
-                  true,
+                "rounded bg-magenta-500 p-2 text-white": true,
                 "animate-pulse": fetchingGroups(),
               }}
               onClick={() => updateGroup()}
@@ -757,12 +755,12 @@ export const GroupPage = (props: GroupPageProps) => {
                             </Show>
                           </div>
                           <a
-                            title="View group"
+                            title="Open group to edit, view its chunks, or test group recommendations"
                             href={`/group/${
                               groupResult.group.id
                             }?dataset=${dataset()?.dataset.id}`}
                           >
-                            <VsFileSymlinkFile class="h-5 w-5 fill-current" />
+                            <FiEye class="h-5 w-5" />
                           </a>
                         </div>
                       </div>

--- a/frontends/search/src/components/ResultsPage.tsx
+++ b/frontends/search/src/components/ResultsPage.tsx
@@ -45,7 +45,7 @@ import {
 } from "../hooks/useSearch";
 import { downloadFile } from "../utils/downloadFile";
 import ScoreChunk from "./ScoreChunk";
-import { VsFileSymlinkFile } from "solid-icons/vs";
+import { FiEye } from "solid-icons/fi";
 
 export interface ResultsPageProps {
   search: SearchStore;
@@ -561,12 +561,12 @@ const ResultsPage = (props: ResultsPageProps) => {
                             )}
                           </Show>
                           <a
-                            title="View group"
+                            title="Open group to edit, view its chunks, or test group recommendations"
                             href={`/group/${
                               groupResult.group.id
                             }?dataset=${dataset()?.dataset.id}`}
                           >
-                            <VsFileSymlinkFile class="h-5 w-5 fill-current" />
+                            <FiEye class="h-5 w-5" />
                           </a>
                         </div>
                       </div>

--- a/frontends/search/src/components/ScoreChunk.tsx
+++ b/frontends/search/src/components/ScoreChunk.tsx
@@ -23,7 +23,7 @@ import {
 } from "../utils/apiTypes";
 import { BiRegularChevronDown, BiRegularChevronUp } from "solid-icons/bi";
 import BookmarkPopover from "./BookmarkPopover";
-import { VsFileSymlinkFile } from "solid-icons/vs";
+import { FiEye } from "solid-icons/fi";
 import sanitizeHtml from "sanitize-html";
 import { FiEdit, FiTrash } from "solid-icons/fi";
 import { Tooltip } from "shared/ui";
@@ -249,10 +249,10 @@ const ScoreChunk = (props: ScoreChunkProps) => {
                       props.chunk.id
                     }?dataset=${$currentDataset?.()?.dataset.id}`}
                   >
-                    <VsFileSymlinkFile class="h-5 w-5 fill-current" />
+                    <FiEye class="h-5 w-5" />
                   </A>
                 }
-                tooltipText="Open in new tab"
+                tooltipText="Open chunk to test recommendations for similar chunks"
                 direction="left"
               />
               <Show when={currentUserRole() > 0}>

--- a/server/migrations/2024-08-02-173037_add-index-on-created_at/down.sql
+++ b/server/migrations/2024-08-02-173037_add-index-on-created_at/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX chunk_metadata_created_at_idx;
+DROP INDEX groups_created_at_idx;
+DROP INDEX files_created_at_idx;

--- a/server/migrations/2024-08-02-173037_add-index-on-created_at/up.sql
+++ b/server/migrations/2024-08-02-173037_add-index-on-created_at/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+CREATE INDEX chunk_metadata_created_at_idx ON chunk_metadata (created_at);
+CREATE INDEX groups_created_at_idx ON chunk_group (created_at);
+CREATE INDEX files_created_at_idx ON files (created_at);

--- a/server/migrations/2024-08-02-174246_delete_pg_events_table/down.sql
+++ b/server/migrations/2024-08-02-174246_delete_pg_events_table/down.sql
@@ -1,0 +1,11 @@
+-- This file should undo anything in `up.sql`
+CREATE TABLE public.events (
+	id uuid NOT NULL,
+	created_at timestamp DEFAULT now() NOT NULL,
+	updated_at timestamp DEFAULT now() NOT NULL,
+	dataset_id uuid NOT NULL,
+	event_type varchar(255) NOT NULL,
+	event_data jsonb NOT NULL,
+	CONSTRAINT file_upload_completed_notifications_pkey PRIMARY KEY (id),
+	CONSTRAINT events_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.datasets(id) ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/server/migrations/2024-08-02-174246_delete_pg_events_table/up.sql
+++ b/server/migrations/2024-08-02-174246_delete_pg_events_table/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+DROP TABLE IF EXISTS events;

--- a/server/src/bin/delete-worker.rs
+++ b/server/src/bin/delete-worker.rs
@@ -13,7 +13,7 @@ use trieve_server::{
     establish_connection, get_env,
     operators::{
         dataset_operator::{
-            delete_chunks_in_dataset, delete_dataset_by_id_query, get_deleted_dataset_by_id_query,
+            delete_dataset_by_id_query, delete_items_in_dataset, get_deleted_dataset_by_id_query,
             DeleteMessage,
         },
         event_operator::create_event_query,
@@ -239,8 +239,9 @@ async fn delete_worker(
 
         if delete_worker_message.empty_dataset {
             log::info!("Cleaning dataset {:?}", delete_worker_message.dataset_id);
-            match delete_chunks_in_dataset(
+            match delete_items_in_dataset(
                 delete_worker_message.dataset_id,
+                delete_worker_message.deleted_at,
                 web_pool.clone(),
                 clickhouse_client.clone(),
                 dataset_config.clone(),
@@ -289,6 +290,7 @@ async fn delete_worker(
 
         match delete_dataset_by_id_query(
             delete_worker_message.dataset_id,
+            delete_worker_message.deleted_at,
             web_pool.clone(),
             clickhouse_client.clone(),
             dataset_config.clone(),

--- a/server/src/data/schema.rs
+++ b/server/src/data/schema.rs
@@ -97,18 +97,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    events (id) {
-        id -> Uuid,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-        dataset_id -> Uuid,
-        #[max_length = 255]
-        event_type -> Varchar,
-        event_data -> Jsonb,
-    }
-}
-
-diesel::table! {
     files (id) {
         id -> Uuid,
         file_name -> Text,
@@ -285,7 +273,6 @@ diesel::joinable!(dataset_event_counts -> datasets (dataset_uuid));
 diesel::joinable!(dataset_tags -> datasets (dataset_id));
 diesel::joinable!(dataset_usage_counts -> datasets (dataset_id));
 diesel::joinable!(datasets -> organizations (organization_id));
-diesel::joinable!(events -> datasets (dataset_id));
 diesel::joinable!(files -> datasets (dataset_id));
 diesel::joinable!(groups_from_files -> chunk_group (group_id));
 diesel::joinable!(groups_from_files -> files (file_id));
@@ -310,7 +297,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     dataset_tags,
     dataset_usage_counts,
     datasets,
-    events,
     files,
     groups_from_files,
     invitations,

--- a/server/src/handlers/dataset_handler.rs
+++ b/server/src/handlers/dataset_handler.rs
@@ -290,7 +290,7 @@ pub async fn delete_dataset(
 
 /// Clear Dataset
 ///
-/// Clears a dataset. The auth'ed user must be an owner of the organization to clear a dataset.
+/// Removes all chunks, files, and groups from the dataset while retaining the analytics and dataset itself. The auth'ed user must be an owner of the organization to clear a dataset.
 #[utoipa::path(
     put,
     path = "/dataset/clear/{dataset_id}",
@@ -328,6 +328,7 @@ pub async fn clear_dataset(
     let config = DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration);
 
     clear_dataset_by_dataset_id_query(data.into_inner(), config, redis_pool).await?;
+
     Ok(HttpResponse::NoContent().finish())
 }
 


### PR DESCRIPTION
This PR modifies clear to remove all data including files and groups on clear then additionally not delete anything which is added to the dataset after the clear operation occurs. 