### PR TITLE
feature: enable debug symbols in production

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 default-run = "trieve-server"
 
 [profile.release]
-debug = 0
+debug = true
 incremental = true
 lto = "fat"
 opt-level = 3


### PR DESCRIPTION
In an attempt to find the memory leak that is happneing in the current main branch add debug symbols to measure memory perf.