### PR TITLE
feature: fix unwrap errors in bm25 boosts and get_point_ids_from_unified_chunk_ids

### DIFF
--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -92,8 +92,8 @@ pub async fn get_point_ids_from_unified_chunk_ids(
 
     let mut conn = pool.get().await.unwrap();
 
-    let qdrant_point_ids: Vec<uuid::Uuid> = match chunk_ids[0] {
-        UnifiedId::TrieveUuid(_) => chunk_metadata_columns::chunk_metadata
+    let qdrant_point_ids: Vec<uuid::Uuid> = match chunk_ids.get(0) {
+        Some(UnifiedId::TrieveUuid(_)) => chunk_metadata_columns::chunk_metadata
             .filter(
                 chunk_metadata_columns::id.eq_any(
                     &chunk_ids
@@ -107,7 +107,7 @@ pub async fn get_point_ids_from_unified_chunk_ids(
             .load::<uuid::Uuid>(&mut conn)
             .await
             .map_err(|_| ServiceError::BadRequest("Failed to load metadata".to_string()))?,
-        UnifiedId::TrackingId(_) => chunk_metadata_columns::chunk_metadata
+        Some(UnifiedId::TrackingId(_)) => chunk_metadata_columns::chunk_metadata
             .filter(
                 chunk_metadata_columns::tracking_id.eq_any(
                     &chunk_ids
@@ -121,6 +121,7 @@ pub async fn get_point_ids_from_unified_chunk_ids(
             .load::<uuid::Uuid>(&mut conn)
             .await
             .map_err(|_| ServiceError::BadRequest("Failed to load metadata".to_string()))?,
+        None => vec![],
     };
 
     Ok(qdrant_point_ids)

--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -1072,7 +1072,7 @@ pub fn term_frequency(
             for token in batch.iter() {
                 let token_id =
                     (murmur3_32(&mut Cursor::new(token), 0).unwrap() as i32).unsigned_abs();
-                let num_occurences = raw_freqs[token];
+                let num_occurences = raw_freqs.get(token).unwrap_or(&0f32);
 
                 let top = num_occurences * (k + 1f32);
                 let bottom = num_occurences + k * (1f32 - b + b * doc_len / avg_len);
@@ -1086,7 +1086,7 @@ pub fn term_frequency(
                     let token_id =
                         (murmur3_32(&mut Cursor::new(token), 0).unwrap() as i32).unsigned_abs();
 
-                    let value = tf_map[&token_id];
+                    let value = tf_map.get(&token_id).unwrap_or(&0f32);
                     tf_map.insert(token_id, fulltext_boost.boost_factor as f32 * value);
                 }
             }


### PR DESCRIPTION
Saw this error happening on Hackernews. I suspect it happens when the phrase isn't present in the text.