### PR TITLE
cleanup: fix typo: Simularity => Similarity

### DIFF
--- a/frontends/shared/types.ts
+++ b/frontends/shared/types.ts
@@ -302,7 +302,7 @@ export const availableEmbeddingModels = [
 export const availableDistanceMetrics = [
   {
     id: "cosine",
-    name: "Cosine Simularity",
+    name: "Cosine Similarity",
   },
   {
     id: "euclidean",


### PR DESCRIPTION
This fixes a typo that appears in the Create New Dataset modal:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/a05889d1-3d38-4eb3-8333-4d531861eba4">
