### PR TITLE
feature: ignore title boosting w/ scrape + bugfix: datasets refreshing on org change in dashboard"

### DIFF
--- a/frontends/dashboard/src/components/DatasetOverview.tsx
+++ b/frontends/dashboard/src/components/DatasetOverview.tsx
@@ -51,7 +51,7 @@ export const DatasetOverview = () => {
 
   const { datasets, maxPageDiscovered, maxDatasets, hasLoaded } =
     useDatasetPages({
-      org: userContext.selectedOrg().id,
+      org: userContext.selectedOrg,
       searchQuery: datasetSearchQuery,
       page: page,
       setPage,

--- a/frontends/dashboard/src/hooks/useDatasetPages.ts
+++ b/frontends/dashboard/src/hooks/useDatasetPages.ts
@@ -46,7 +46,7 @@ const getDatasets = async ({ orgId }: { orgId: string }) => {
 };
 
 export const useDatasetPages = (props: {
-  org: string;
+  org: () => { id: string };
   page: Accessor<number>;
   searchQuery: Accessor<string>;
   setPage: (page: number) => void;
@@ -55,7 +55,7 @@ export const useDatasetPages = (props: {
   const [realDatasets, setRealDatasets] = createSignal<DatasetAndUsage[]>([]);
 
   createEffect(() => {
-    const org_id = props.org;
+    const org_id = props.org().id;
 
     if (!org_id) {
       return;
@@ -91,6 +91,7 @@ export const useDatasetPages = (props: {
       props.page() * PAGE_SIZE,
       (props.page() + 1) * PAGE_SIZE,
     );
+
     return sliced;
   });
 

--- a/server/src/bin/crawl-worker.rs
+++ b/server/src/bin/crawl-worker.rs
@@ -167,14 +167,22 @@ async fn crawl(
                 ))),
                 upsert_by_tracking_id: Some(true),
                 group_tracking_ids: Some(vec![page_link.clone()]),
-                fulltext_boost: Some(FullTextBoost {
-                    phrase: fulltext_boost_phrase,
-                    boost_factor: 1.3,
-                }),
-                semantic_boost: Some(SemanticBoost {
-                    phrase: semantic_boost_phrase,
-                    distance_factor: 0.3,
-                }),
+                fulltext_boost: if scrape_request.crawl_options.boost_titles.unwrap_or(true) {
+                    Some(FullTextBoost {
+                        phrase: fulltext_boost_phrase,
+                        boost_factor: 1.3,
+                    })
+                } else {
+                    None
+                },
+                semantic_boost: if scrape_request.crawl_options.boost_titles.unwrap_or(true) {
+                    Some(SemanticBoost {
+                        phrase: semantic_boost_phrase,
+                        distance_factor: 0.3,
+                    })
+                } else {
+                    None
+                },
                 convert_html_to_text: Some(true),
                 ..Default::default()
             };

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -5978,10 +5978,10 @@ impl From<CrawlRequest> for CrawlRequestPG {
 #[schema(example=json!({
     "site_url": "https://example.com",
     "interval": "daily",
-    "limit": 20,
+    "limit": 1000,
     "exclude_paths": ["https://example.com/exclude"],
     "include_paths": ["https://example.com/include"],
-    "max_depth": 2,
+    "max_depth": 10,
     "include_tags": ["h1", "p", "a", ".main-content"],
     "exclude_tags": ["#ad", "#footer"],
 }))]
@@ -6002,6 +6002,8 @@ pub struct CrawlOptions {
     pub include_tags: Option<Vec<String>>,
     /// Specify the HTML tags, classes and ids to exclude from the response.
     pub exclude_tags: Option<Vec<String>>,
+    /// Boost titles such that keyword matches in titles are prioritized in search results. Strongly recommended to leave this on. Defaults to true.
+    pub boost_titles: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -41,7 +41,7 @@ use simple_server_timing_header::Timer;
 use tokio_stream::StreamExt;
 use utoipa::ToSchema;
 
-/// Boost phrase is useful for when you want to boost certain phrases in the fulltext (SPLADE) and BM25 search results. I.e. making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the in-document-frequency of the AirBNB token (AKA word) for its official listing. Conceptually it multiples the in-document-importance second value in the tuples of the SPLADE or BM25 sparse vector of the chunk_html innerText for all tokens present in the boost phrase by the boost factor like so: (token, in-document-importance) -> (token, in-document-importance*boost_factor).
+/// Boost the presence of certain tokens for fulltext (SPLADE) and keyword (BM25) search. I.e. boosting title phrases to priortize title matches or making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the in-document-frequency of the AirBNB token (AKA word) for its official listing. Conceptually it multiples the in-document-importance second value in the tuples of the SPLADE or BM25 sparse vector of the chunk_html innerText for all tokens present in the boost phrase by the boost factor like so: (token, in-document-importance) -> (token, in-document-importance*boost_factor).
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct FullTextBoost {
     /// The phrase to boost in the fulltext document frequency index
@@ -50,7 +50,7 @@ pub struct FullTextBoost {
     pub boost_factor: f64,
 }
 
-/// Distance phrase is useful for moving the embedding vector of the chunk in the direction of the distance phrase. I.e. you can push a chunk with a chunk_html of "iphone" 25% closer to the term "flagship" by using the distance phrase "flagship" and a distance factor of 0.25. Conceptually it's drawing a line (euclidean/L2 distance) between the vector for the innerText of the chunk_html and distance_phrase then moving the vector of the chunk_html distance_factor*L2Distance closer to or away from the distance_phrase point along the line between the two points.
+/// Semantic boosting moves the dense vector of the chunk in the direction of the distance phrase for semantic search. I.e. you can force a cluster by moving every chunk for a PDF closer to its title or push a chunk with a chunk_html of "iphone" 25% closer to the term "flagship" by using the distance phrase "flagship" and a distance factor of 0.25. Conceptually it's drawing a line (euclidean/L2 distance) between the vector for the innerText of the chunk_html and distance_phrase then moving the vector of the chunk_html distance_factor*L2Distance closer to or away from the distance_phrase point along the line between the two points.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct SemanticBoost {
     /// Terms to embed in order to create the vector which is weighted summed with the chunk_html embedding vector
@@ -62,9 +62,9 @@ pub struct SemanticBoost {
 /// Scoring options provides ways to modify the sparse or dense vector created for the query in order to change how potential matches are scored. If not specified, this defaults to no modifications.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ScoringOptions {
-    ///  Full text boost is useful for when you want to boost certain phrases in the fulltext (SPLADE) and BM25 search results. I.e. making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the in-document-frequency of the AirBNB token (AKA word) for its official listing. Conceptually it multiples the in-document-importance second value in the tuples of the SPLADE or BM25 sparse vector of the chunk_html innerText for all tokens present in the boost phrase by the boost factor like so: (token, in-document-importance) -> (token, in-document-importance*boost_factor).
+    /// Boost the presence of certain tokens for fulltext (SPLADE) and keyword (BM25) search. I.e. boosting title phrases to priortize title matches or making sure that the listing for AirBNB itself ranks higher than companies who make software for AirBNB hosts by boosting the in-document-frequency of the AirBNB token (AKA word) for its official listing. Conceptually it multiples the in-document-importance second value in the tuples of the SPLADE or BM25 sparse vector of the chunk_html innerText for all tokens present in the boost phrase by the boost factor like so: (token, in-document-importance) -> (token, in-document-importance*boost_factor).
     pub fulltext_boost: Option<FullTextBoost>,
-    /// Semantic boost is useful for moving the embedding vector of the chunk in the direction of the distance phrase. I.e. you can push a chunk with a chunk_html of "iphone" 25% closer to the term "flagship" by using the distance phrase "flagship" and a distance factor of 0.25. Conceptually it's drawing a line (euclidean/L2 distance) between the vector for the innerText of the chunk_html and distance_phrase then moving the vector of the chunk_html distance_factor*L2Distance closer to or away from the distance_phrase point along the line between the two points.
+    /// Semantic boosting moves the dense vector of the chunk in the direction of the distance phrase for semantic search. I.e. you can force a cluster by moving every chunk for a PDF closer to its title or push a chunk with a chunk_html of "iphone" 25% closer to the term "flagship" by using the distance phrase "flagship" and a distance factor of 0.25. Conceptually it's drawing a line (euclidean/L2 distance) between the vector for the innerText of the chunk_html and distance_phrase then moving the vector of the chunk_html distance_factor*L2Distance closer to or away from the distance_phrase point along the line between the two points.
     pub semantic_boost: Option<SemanticBoost>,
 }
 


### PR DESCRIPTION
- **feature: allow for boosting to be prevented when scraping**
- **bugfix: datasets in table not reloading when org selected changes**
