### PR TITLE
bugfix: don't filter duplicates when fetching search queries

### DIFF
--- a/server/src/operators/analytics_operator.rs
+++ b/server/src/operators/analytics_operator.rs
@@ -116,7 +116,7 @@ pub async fn get_search_query(
     clickhouse_client: &clickhouse::Client,
 ) -> Result<SearchQueryEvent, ServiceError> {
     let clickhouse_query = clickhouse_client
-        .query("SELECT ?fields FROM search_queries WHERE id = ? AND dataset_id = ? AND search_queries.is_duplicate = 0")
+        .query("SELECT ?fields FROM search_queries WHERE id = ? AND dataset_id = ?")
         .bind(search_id)
         .bind(dataset_id)
         .fetch_one::<SearchQueryEventClickhouse>()


### PR DESCRIPTION
I suspect that rag queries are being collapsed and thus are non fetch-able, causing a 500 error on `/api/analytics/search`. This is an easy fix as we don't fully delete collapsed queries. 