### PR TITLE
bugfix: use rag queries for results

### DIFF
--- a/frontends/dashboard/src/analytics/components/SingleQueryInfo/ResultCard.tsx
+++ b/frontends/dashboard/src/analytics/components/SingleQueryInfo/ResultCard.tsx
@@ -43,9 +43,11 @@ export const ResultCard = (props: ResultCardProps) => {
 
             <IoCode />
           </div>
-          <div class="text-xs font-normal opacity-60">
-            Score: {props?.result?.score.toFixed(5)}
-          </div>
+          <Show when={props?.result?.score}>
+            <div class="text-xs font-normal opacity-60">
+              Score: {props?.result?.score?.toFixed(5)}
+            </div>
+          </Show>
           <Show when={metadata()}>
             {(metadata) => (
               <div class="line-clamp-1 font-mono text-xs text-zinc-600">

--- a/frontends/dashboard/src/analytics/components/SingleRagInfo/index.tsx
+++ b/frontends/dashboard/src/analytics/components/SingleRagInfo/index.tsx
@@ -91,9 +91,9 @@ export const SingleRAGQuery = (props: SingleRAGQueryProps) => {
           <div class="grid gap-4 sm:grid-cols-2">
             <For
               fallback={<div class="py-8 text-center">No Data.</div>}
-              each={props.search_data.results}
+              each={props.rag_data.results}
             >
-              {(result) => <ResultCard result={result} />}
+              {(result) => <ResultCard result={{ metadata: [result] }} />}
             </For>
           </div>
         </Card>

--- a/frontends/shared/types.ts
+++ b/frontends/shared/types.ts
@@ -477,9 +477,9 @@ export interface SearchQueryEvent {
   latency: number;
   top_score: number;
   results: {
-    highlights: unknown;
+    highlights?: unknown;
     metadata: ChunkMetadataStringTagSet[];
-    score: number;
+    score?: number;
   }[];
   dataset_id: string;
   created_at: string;


### PR DESCRIPTION
If #2511 does not fix the error, we  can default swap to rag_queries.results if there is no easy fix.