### PR TITLE
feature: send last chunks image_urls into chat model

### DIFF
--- a/frontends/chat/src/components/Layouts/MainLayout.tsx
+++ b/frontends/chat/src/components/Layouts/MainLayout.tsx
@@ -77,6 +77,11 @@ const MainLayout = (props: LayoutProps) => {
     boolean | null
   >(null);
 
+  const [useImages, setUseImages] = createSignal<
+    boolean | null
+  >(null);
+
+
   const [streamCompletionsFirst, setStreamCompletionsFirst] = createSignal<
     boolean | null
   >(null);
@@ -221,6 +226,9 @@ const MainLayout = (props: LayoutProps) => {
           system_prompt: systemPrompt(),
           llm_options: {
             completion_first: streamCompletionsFirst(),
+            image_options: {
+              use_images: useImages()
+            }
           },
           search_type: searchType(),
         }),
@@ -339,6 +347,9 @@ const MainLayout = (props: LayoutProps) => {
                         topic_id: props.selectedTopic?.id,
                         llm_options: {
                           completion_first: streamCompletionsFirst(),
+                          image_options: {
+                            use_images: useImages()
+                          }
                         },
                       }),
                     })
@@ -446,6 +457,20 @@ const MainLayout = (props: LayoutProps) => {
                       checked={concatUserMessagesQuery() ?? false}
                       onChange={(e) => {
                         setConcatUserMessagesQuery(e.target.checked);
+                      }}
+                    />
+                  </div>
+                  <div class="flex w-full items-center gap-x-2">
+                    <label for="concat_user_messages">
+                      Use Images
+                    </label>
+                    <input
+                      type="checkbox"
+                      id="concat_user_messages"
+                      class="h-4 w-4 rounded-md border border-neutral-300 bg-neutral-100 p-1 dark:border-neutral-900 dark:bg-neutral-800"
+                      checked={useImages() ?? false}
+                      onChange={(e) => {
+                        setUseImages(e.target.checked);
                       }}
                     />
                   </div>

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -5610,6 +5610,19 @@ pub struct TypoRange {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Default)]
+#[schema(example = json!({
+    "use_images": true,
+    "images_per_chunk": 1
+}))]
+/// Configuration for sending images to the llm
+pub struct ImageConfig {
+    /// This sends images to the llm if chunk_metadata.image_urls has some value, the call will error if the model is not a vision LLM model. default: false
+    pub use_images: Option<bool>,
+    /// The number of Images to send to the llm per chunk that is fetched more images may slow down llm inference time. default: 5
+    pub images_per_chunk: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Default)]
 /// LLM options to use for the completion. If not specified, this defaults to the dataset's LLM options.
 pub struct LLMOptions {
     /// Completion first decides whether the stream should contain the stream of the completion response or the chunks first. Default is false. Keep in mind that || is used to separate the chunks from the completion response. If || is in the completion then you may want to split on ||{ instead.
@@ -5628,6 +5641,8 @@ pub struct LLMOptions {
     pub stop_tokens: Option<Vec<String>>,
     /// Optionally, override the system prompt in dataset server settings.
     pub system_prompt: Option<String>,
+    /// Configuration for sending images to the llm
+    pub image_config: Option<ImageConfig>,
 }
 
 // Helper function to extract SortOptions and HighlightOptions

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -430,6 +430,7 @@ impl Modify for SecurityAddon {
             data::models::QdrantSortBy,
             data::models::SortOptions,
             data::models::LLMOptions,
+            data::models::ImageConfig,
             data::models::HighlightOptions,
             data::models::TypoOptions,
             data::models::TypoRange,


### PR DESCRIPTION
This adds a new set of parameters to LLMOptions:

```sh
llm_options: {
   image_config: {
      use_images: true,
      images_per_chunk: 5
   }
}
```

When enabled, the generation routes will send up to `images_per_chunk` image urls in `chunk_metadata.image_urls` to the llm.

Tested on openrouter with the following models:
- `openai/chatgpt-4o-latest` - Better reasoning but 10x slower (~10-15seconds)
- `qwen/qwen-2-vl-7b-instruct` - By far the fastest model, reasoning seems to be a little shy. (~2seconds)
