### PR TITLE
feat: shopify scraping

### DIFF
--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -7480,6 +7480,7 @@
       },
       "CrawlOpenAPIOptions": {
         "type": "object",
+        "title": "CrawlOpenAPIOptions",
         "description": "Options for including an openapi spec in the crawl",
         "required": [
           "openapi_schema_url",
@@ -7544,10 +7545,6 @@
             ],
             "nullable": true
           },
-          "is_shopify": {
-            "type": "boolean",
-            "nullable": true
-          },
           "limit": {
             "type": "integer",
             "format": "int32",
@@ -7560,10 +7557,10 @@
             "description": "How many levels deep to crawl, defaults to 10",
             "nullable": true
           },
-          "openapi_options": {
+          "scrape_options": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CrawlOpenAPIOptions"
+                "$ref": "#/components/schemas/ScrapeOptions"
               }
             ],
             "nullable": true
@@ -7595,6 +7592,16 @@
           "limit": 1000,
           "max_depth": 10,
           "site_url": "https://example.com"
+        }
+      },
+      "CrawlShopifyOptions": {
+        "type": "object",
+        "title": "CrawlShopifyOptions",
+        "properties": {
+          "boost_item_names": {
+            "type": "boolean",
+            "nullable": true
+          }
         }
       },
       "CreateBatchChunkGroupReqPayload": {
@@ -9205,6 +9212,14 @@
             "description": "Set highlight_results to false for a slight latency improvement (1-10ms). If not specified, this defaults to true. This will add `<b><mark>` tags to the chunk_html of the chunks to highlight matching splits.",
             "nullable": true
           },
+          "image_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImageConfig"
+              }
+            ],
+            "nullable": true
+          },
           "max_tokens": {
             "type": "integer",
             "format": "int32",
@@ -9807,6 +9822,27 @@
           "v1"
         ]
       },
+      "ImageConfig": {
+        "type": "object",
+        "description": "Configuration for sending images to the llm",
+        "properties": {
+          "images_per_chunk": {
+            "type": "integer",
+            "description": "The number of Images to send to the llm per chunk that is fetched more images may slow down llm inference time. default: 5",
+            "nullable": true,
+            "minimum": 0
+          },
+          "use_images": {
+            "type": "boolean",
+            "description": "This sends images to the llm if chunk_metadata.image_urls has some value, the call will error if the model is not a vision LLM model. default: false",
+            "nullable": true
+          }
+        },
+        "example": {
+          "images_per_chunk": 1,
+          "use_images": true
+        }
+      },
       "Invitation": {
         "type": "object",
         "required": [
@@ -9897,6 +9933,14 @@
             "type": "number",
             "format": "float",
             "description": "Frequency penalty is a number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Default is 0.7.",
+            "nullable": true
+          },
+          "image_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImageConfig"
+              }
+            ],
             "nullable": true
           },
           "max_tokens": {
@@ -11557,6 +11601,56 @@
             ],
             "nullable": true
           }
+        }
+      },
+      "ScrapeOptions": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CrawlOpenAPIOptions"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "openapi"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CrawlShopifyOptions"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "shopify"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "description": "Options for including an openapi spec or shopify settigns",
+        "discriminator": {
+          "propertyName": "type"
         }
       },
       "ScrollChunksReqPayload": {

--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -40,7 +40,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -143,7 +144,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -197,7 +199,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -258,7 +261,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -317,7 +321,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -371,7 +376,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -432,7 +438,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -491,7 +498,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -545,7 +553,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -606,7 +615,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -813,7 +823,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -892,7 +903,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -946,7 +958,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1021,7 +1034,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1082,7 +1096,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1152,7 +1167,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1227,7 +1243,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1302,7 +1319,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1363,7 +1381,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1418,7 +1437,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1499,7 +1519,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1551,7 +1572,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1633,7 +1655,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1686,7 +1709,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1755,7 +1779,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1809,7 +1834,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1871,7 +1897,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1951,7 +1978,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -2015,7 +2043,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2090,7 +2119,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2165,7 +2195,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2240,7 +2271,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2334,7 +2366,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2401,7 +2434,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2462,7 +2496,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2525,7 +2560,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2586,7 +2622,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2654,7 +2691,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2716,7 +2754,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2812,7 +2851,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -2900,7 +2940,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -2961,7 +3002,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3039,7 +3081,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3098,7 +3141,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3169,7 +3213,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3232,7 +3277,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3302,7 +3348,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3376,7 +3423,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3437,7 +3485,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3507,7 +3556,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3602,7 +3652,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3664,7 +3715,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3734,7 +3786,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3802,7 +3855,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -3865,7 +3919,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3926,7 +3981,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3987,7 +4043,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4055,7 +4112,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4142,7 +4200,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4196,7 +4255,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4249,7 +4309,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4312,7 +4373,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4380,7 +4442,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4441,7 +4504,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4510,7 +4574,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4580,7 +4645,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4691,7 +4757,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4752,7 +4819,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -4806,7 +4874,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4866,7 +4935,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4929,7 +4999,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -4997,7 +5068,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -5237,7 +5309,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -5290,7 +5363,8 @@
             "description": "The organization id to use for the request",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -5353,7 +5427,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -5412,7 +5487,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -5536,7 +5612,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -5589,7 +5666,8 @@
             "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -7268,6 +7346,7 @@
       },
       "ContentChunkMetadata": {
         "type": "object",
+        "title": "ContentChunkMetadata",
         "required": [
           "id",
           "weight"
@@ -7463,6 +7542,10 @@
                 "$ref": "#/components/schemas/CrawlInterval"
               }
             ],
+            "nullable": true
+          },
+          "is_shopify": {
+            "type": "boolean",
             "nullable": true
           },
           "limit": {
@@ -12932,6 +13015,7 @@
       },
       "SlimChunkMetadataWithArrayTagSet": {
         "type": "object",
+        "title": "SlimChunkMetadataWithArrayTagSet",
         "required": [
           "id",
           "created_at",

--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -7597,9 +7597,11 @@
       "CrawlShopifyOptions": {
         "type": "object",
         "title": "CrawlShopifyOptions",
+        "description": "Options for Crawling Shopify",
         "properties": {
-          "boost_item_names": {
+          "group_variants": {
             "type": "boolean",
+            "description": "This option will ingest all variants as individual chunks and place them in groups by product id. Turning this off will only scrape 1 variant per product. default: true",
             "nullable": true
           }
         }

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -454,7 +454,6 @@ export type CrawlOptions = {
      */
     include_tags?: Array<(string)> | null;
     interval?: ((CrawlInterval) | null);
-    is_shopify?: (boolean) | null;
     /**
      * How many pages to crawl, defaults to 1000
      */
@@ -463,11 +462,15 @@ export type CrawlOptions = {
      * How many levels deep to crawl, defaults to 10
      */
     max_depth?: (number) | null;
-    openapi_options?: ((CrawlOpenAPIOptions) | null);
+    scrape_options?: ((ScrapeOptions) | null);
     /**
      * The URL to crawl
      */
     site_url?: (string) | null;
+};
+
+export type CrawlShopifyOptions = {
+    boost_item_names?: (boolean) | null;
 };
 
 export type CreateBatchChunkGroupReqPayload = Array<CreateSingleChunkGroupReqPayload>;
@@ -1042,6 +1045,7 @@ export type GenerateOffChunksReqPayload = {
      * Set highlight_results to false for a slight latency improvement (1-10ms). If not specified, this defaults to true. This will add `<b><mark>` tags to the chunk_html of the chunks to highlight matching splits.
      */
     highlight_results?: (boolean) | null;
+    image_config?: ((ImageConfig) | null);
     /**
      * The maximum number of tokens to generate in the chat completion. Default is None.
      */
@@ -1249,6 +1253,20 @@ export type HighlightOptions = {
 
 export type HighlightStrategy = 'exactmatch' | 'v1';
 
+/**
+ * Configuration for sending images to the llm
+ */
+export type ImageConfig = {
+    /**
+     * The number of Images to send to the llm per chunk that is fetched more images may slow down llm inference time. default: 5
+     */
+    images_per_chunk?: (number) | null;
+    /**
+     * This sends images to the llm if chunk_metadata.image_urls has some value, the call will error if the model is not a vision LLM model. default: false
+     */
+    use_images?: (boolean) | null;
+};
+
 export type Invitation = {
     created_at: string;
     email: string;
@@ -1290,6 +1308,7 @@ export type LLMOptions = {
      * Frequency penalty is a number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. Default is 0.7.
      */
     frequency_penalty?: (number) | null;
+    image_config?: ((ImageConfig) | null);
     /**
      * The maximum number of tokens to generate in the chat completion. Default is None.
      */
@@ -1724,6 +1743,17 @@ export type ScoringOptions = {
     semantic_boost?: ((SemanticBoost) | null);
 };
 
+/**
+ * Options for including an openapi spec or shopify settigns
+ */
+export type ScrapeOptions = (CrawlOpenAPIOptions & {
+    type: 'openapi';
+}) | (CrawlShopifyOptions & {
+    type: 'shopify';
+});
+
+export type type5 = 'openapi';
+
 export type ScrollChunksReqPayload = {
     filters?: ((ChunkFilter) | null);
     /**
@@ -1782,7 +1812,7 @@ export type SearchAnalytics = {
     type: 'popular_filters';
 };
 
-export type type5 = 'latency_graph';
+export type type6 = 'latency_graph';
 
 export type SearchAnalyticsFilter = {
     date_range?: ((DateRange) | null);

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -454,6 +454,7 @@ export type CrawlOptions = {
      */
     include_tags?: Array<(string)> | null;
     interval?: ((CrawlInterval) | null);
+    is_shopify?: (boolean) | null;
     /**
      * How many pages to crawl, defaults to 1000
      */

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -469,8 +469,14 @@ export type CrawlOptions = {
     site_url?: (string) | null;
 };
 
+/**
+ * Options for Crawling Shopify
+ */
 export type CrawlShopifyOptions = {
-    boost_item_names?: (boolean) | null;
+    /**
+     * This option will ingest all variants as individual chunks and place them in groups by product id. Turning this off will only scrape 1 variant per product. default: true
+     */
+    group_variants?: (boolean) | null;
 };
 
 export type CreateBatchChunkGroupReqPayload = Array<CreateSingleChunkGroupReqPayload>;

--- a/frontends/chat/src/components/Layouts/MainLayout.tsx
+++ b/frontends/chat/src/components/Layouts/MainLayout.tsx
@@ -77,10 +77,7 @@ const MainLayout = (props: LayoutProps) => {
     boolean | null
   >(null);
 
-  const [useImages, setUseImages] = createSignal<
-    boolean | null
-  >(null);
-
+  const [useImages, setUseImages] = createSignal<boolean | null>(null);
 
   const [streamCompletionsFirst, setStreamCompletionsFirst] = createSignal<
     boolean | null
@@ -227,8 +224,8 @@ const MainLayout = (props: LayoutProps) => {
           llm_options: {
             completion_first: streamCompletionsFirst(),
             image_options: {
-              use_images: useImages()
-            }
+              use_images: useImages(),
+            },
           },
           search_type: searchType(),
         }),
@@ -348,8 +345,8 @@ const MainLayout = (props: LayoutProps) => {
                         llm_options: {
                           completion_first: streamCompletionsFirst(),
                           image_options: {
-                            use_images: useImages()
-                          }
+                            use_images: useImages(),
+                          },
                         },
                       }),
                     })
@@ -461,9 +458,7 @@ const MainLayout = (props: LayoutProps) => {
                     />
                   </div>
                   <div class="flex w-full items-center gap-x-2">
-                    <label for="concat_user_messages">
-                      Use Images
-                    </label>
+                    <label for="concat_user_messages">Use Images</label>
                     <input
                       type="checkbox"
                       id="concat_user_messages"

--- a/frontends/dashboard/src/components/NewDatasetModal.tsx
+++ b/frontends/dashboard/src/components/NewDatasetModal.tsx
@@ -1049,6 +1049,59 @@ export const NewDatasetModal = (props: NewDatasetModalProps) => {
                                 />
                               </div>
                             </Match>
+                            <Match
+                              when={
+                                crawlOptions()?.scrape_options?.type ==
+                                "shopify"
+                              }
+                            >
+                              <div class="content-center py-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">
+                                <label
+                                  for="groupVariants"
+                                  class="flex h-full items-center gap-2 pt-1.5 text-sm font-medium leading-6"
+                                >
+                                  Group Product Variants
+                                  <Tooltip
+                                    body={
+                                      <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                                    }
+                                    tooltipText="This option will ingest all variants as individual chunks and place them in groups by product id. Turning this off will only scrape 1 variant per product"
+                                    direction="right"
+                                  />
+                                </label>
+                                <input
+                                  type="checkbox"
+                                  id="groupVariants"
+                                  name="groupVariants"
+                                  class="col-span-2 mt-2.5 block w-fit rounded-md border-[0.5px] border-neutral-300 bg-white px-3 text-start placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
+                                  checked={
+                                    crawlOptions()?.scrape_options
+                                      .group_variants ?? true
+                                  }
+                                  onChange={(e) =>
+                                    setCrawlOptions((prev) => {
+                                      if (!prev) {
+                                        console.log(e.currentTarget.value);
+                                        return {
+                                          scrape_options: {
+                                            type: "shopify",
+                                            group_variants: e.currentTarget.checked,
+                                          },
+                                        };
+                                      }
+
+                                      return {
+                                        ...prev,
+                                        scrape_options: {
+                                          type: "shopify",
+                                          group_variants: e.currentTarget.checked,
+                                        },
+                                      };
+                                    })
+                                  }
+                                />
+                              </div>
+                            </Match>
                           </Switch>
                         </div>
                       </Show>

--- a/frontends/dashboard/src/components/NewDatasetModal.tsx
+++ b/frontends/dashboard/src/components/NewDatasetModal.tsx
@@ -1,6 +1,7 @@
 import {
   Accessor,
   createSignal,
+  createEffect,
   useContext,
   For,
   Switch,
@@ -131,6 +132,10 @@ export const NewDatasetModal = (props: NewDatasetModalProps) => {
       });
     }
   };
+
+  createEffect(() => {
+    console.log(crawlOptions());
+  });
 
   return (
     <Transition appear show={props.isOpen()}>
@@ -828,101 +833,223 @@ export const NewDatasetModal = (props: NewDatasetModalProps) => {
                             />
                           </div>
 
-                          <div class="content-center py-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">
-                            <label
-                              for="openapiSchemaUrl"
-                              class="flex h-full items-center gap-2 pt-1.5 text-sm font-medium leading-6"
-                            >
-                              OpenAPI Schema URL
-                              <Tooltip
-                                body={
-                                  <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                          <div class="content-center py-4 sm:grid sm:grid-cols-2 sm:items-start sm:gap-4">
+                            <div class="col-span-1 flex">
+                              <input
+                                type="checkbox"
+                                id="useOpenAPI"
+                                name="useOpenAPI"
+                                class="mt-2.5 block w-fit rounded-md border-[0.5px] border-neutral-300 bg-white px-3 text-start placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
+                                checked={
+                                  crawlOptions()?.scrape_options != undefined &&
+                                  crawlOptions()?.scrape_options?.type ==
+                                    "openapi"
                                 }
-                                tooltipText="URL that will return a *.json or *.yaml file with an OpenAPI schema which pairs with the docs."
-                                direction="right"
+                                onChange={(e) =>
+                                  setCrawlOptions((prev) => {
+                                    if (!prev) {
+                                      return {
+                                        scrape_options: {
+                                          type: "openapi",
+                                        },
+                                      };
+                                    }
+                                    if (!e.currentTarget.checked) {
+                                      return {
+                                        ...prev,
+                                        scrape_options: null,
+                                      };
+                                    } else {
+                                      return {
+                                        ...prev,
+                                        scrape_options: {
+                                          type: "openapi",
+                                        },
+                                      };
+                                    }
+                                  })
+                                }
                               />
-                            </label>
-                            <input
-                              type="text"
-                              id="openapiSchemaUrl"
-                              name="openapiSchemaUrl"
-                              class="col-span-2 block w-full rounded-md border-[0.5px] border-neutral-300 bg-white px-3 py-1.5 shadow-sm placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
-                              value={
-                                crawlOptions()?.openapi_options
-                                  ?.openapi_schema_url ?? ""
-                              }
-                              onInput={(e) =>
-                                setCrawlOptions((prev) => {
-                                  if (!prev) {
-                                    return {
-                                      openapi_options: {
-                                        openapi_schema_url:
-                                          e.currentTarget.value,
-                                        openapi_tag: "",
-                                      },
-                                    };
-                                  }
 
-                                  return {
-                                    ...prev,
-                                    openapi_options: {
-                                      openapi_schema_url: e.currentTarget.value,
-                                      openapi_tag:
-                                        prev.openapi_options?.openapi_tag ?? "",
-                                    },
-                                  };
-                                })
-                              }
-                            />
+                              <label
+                                for="useOpenAPI"
+                                class="flex h-full items-center gap-2 pl-1.5 pt-1.5 text-sm font-medium leading-6"
+                              >
+                                OpenAPI spec
+                                <Tooltip
+                                  body={
+                                    <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                                  }
+                                  tooltipText="Parse an OpenAPI spec on a specified route"
+                                  direction="right"
+                                />
+                              </label>
+                            </div>
+                            <div class="col-span-1 flex">
+                              <input
+                                type="checkbox"
+                                id="useShopify"
+                                name="useShopify"
+                                class="mt-2.5 block w-fit rounded-md border-[0.5px] border-neutral-300 bg-white px-3 text-start placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
+                                checked={
+                                  crawlOptions()?.scrape_options != undefined &&
+                                  crawlOptions()?.scrape_options?.type ==
+                                    "shopify"
+                                }
+                                onChange={(e) =>
+                                  setCrawlOptions((prev) => {
+                                    if (!prev) {
+                                      return {
+                                        scrape_options: {
+                                          type: "shopify",
+                                        },
+                                      };
+                                    }
+
+                                    if (!e.currentTarget.checked) {
+                                      return {
+                                        ...prev,
+                                        scrape_options: null,
+                                      };
+                                    } else {
+                                      return {
+                                        ...prev,
+                                        scrape_options: {
+                                          type: "shopify",
+                                        },
+                                      };
+                                    }
+                                  })
+                                }
+                              />
+
+                              <label
+                                for="useShopify"
+                                class="flex h-full items-center gap-2 pl-1.5 pt-1.5 text-sm font-medium leading-6"
+                              >
+                                Is Shopify Store
+                                <Tooltip
+                                  body={
+                                    <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                                  }
+                                  tooltipText="Toggle if the webpage is a shopify store to scrape the products more accurately"
+                                  direction="left"
+                                />
+                              </label>
+                            </div>
                           </div>
 
-                          <div class="content-center py-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">
-                            <label
-                              for="openapiTag"
-                              class="flex h-full items-center gap-2 pt-1.5 text-sm font-medium leading-6"
+                          <Switch>
+                            <Match
+                              when={
+                                crawlOptions()?.scrape_options?.type ==
+                                "openapi"
+                              }
                             >
-                              OpenAPI Tag
-                              <Tooltip
-                                body={
-                                  <FaRegularCircleQuestion class="h-4 w-4 text-black" />
-                                }
-                                tooltipText="For a site like https://docs.trieve.ai, the tag here would be 'api-reference' because of the API routes being documented at https://docs.trieve.ai/api-reference/* paths."
-                                direction="right"
-                              />
-                            </label>
-                            <input
-                              type="text"
-                              id="openapiTag"
-                              name="openapiTag"
-                              class="col-span-2 block w-full rounded-md border-[0.5px] border-neutral-300 bg-white px-3 py-1.5 shadow-sm placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
-                              value={
-                                crawlOptions()?.openapi_options?.openapi_tag ??
-                                ""
-                              }
-                              onInput={(e) =>
-                                setCrawlOptions((prev) => {
-                                  if (!prev) {
-                                    return {
-                                      openapi_options: {
-                                        openapi_schema_url: "",
-                                        openapi_tag: e.currentTarget.value,
-                                      },
-                                    };
+                              <div class="content-center py-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">
+                                <label
+                                  for="openapiSchemaUrl"
+                                  class="flex h-full items-center gap-2 pt-1.5 text-sm font-medium leading-6"
+                                >
+                                  OpenAPI Schema URL
+                                  <Tooltip
+                                    body={
+                                      <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                                    }
+                                    tooltipText="URL that will return a *.json or *.yaml file with an OpenAPI schema which pairs with the docs."
+                                    direction="right"
+                                  />
+                                </label>
+                                <input
+                                  type="text"
+                                  id="openapiSchemaUrl"
+                                  name="openapiSchemaUrl"
+                                  class="col-span-2 block w-full rounded-md border-[0.5px] border-neutral-300 bg-white px-3 py-1.5 shadow-sm placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
+                                  value={
+                                    // @ts-expect-error type is checked in <Match/> component
+                                    crawlOptions()?.scrape_options
+                                      ?.openapi_schema_url ?? ""
                                   }
+                                  onInput={(e) =>
+                                    setCrawlOptions((prev) => {
+                                      if (!prev) {
+                                        return {
+                                          scrape_options: {
+                                            type: "openapi",
+                                            openapi_schema_url:
+                                              e.currentTarget.value,
+                                            openapi_tag: "",
+                                          },
+                                        };
+                                      }
 
-                                  return {
-                                    ...prev,
-                                    openapi_options: {
-                                      openapi_schema_url:
-                                        prev.openapi_options
-                                          ?.openapi_schema_url ?? "",
-                                      openapi_tag: e.currentTarget.value,
-                                    },
-                                  };
-                                })
-                              }
-                            />
-                          </div>
+                                      return {
+                                        ...prev,
+                                        scrape_options: {
+                                          type: "openapi",
+                                          openapi_schema_url:
+                                            e.currentTarget.value,
+                                          openapi_tag:
+                                            prev.scrape_options?.openapi_tag ??
+                                            "",
+                                        },
+                                      };
+                                    })
+                                  }
+                                />
+                              </div>
+
+                              <div class="content-center py-4 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">
+                                <label
+                                  for="openapiTag"
+                                  class="flex h-full items-center gap-2 pt-1.5 text-sm font-medium leading-6"
+                                >
+                                  OpenAPI Tag
+                                  <Tooltip
+                                    body={
+                                      <FaRegularCircleQuestion class="h-4 w-4 text-black" />
+                                    }
+                                    tooltipText="For a site like https://docs.trieve.ai, the tag here would be 'api-reference' because of the API routes being documented at https://docs.trieve.ai/api-reference/* paths."
+                                    direction="right"
+                                  />
+                                </label>
+                                <input
+                                  type="text"
+                                  id="openapiTag"
+                                  name="openapiTag"
+                                  class="col-span-2 block w-full rounded-md border-[0.5px] border-neutral-300 bg-white px-3 py-1.5 shadow-sm placeholder:text-neutral-400 focus:outline-magenta-500 sm:text-sm sm:leading-6"
+                                  value={
+                                    crawlOptions()?.scrape_options
+                                      ?.openapi_tag ?? ""
+                                  }
+                                  onInput={(e) =>
+                                    setCrawlOptions((prev) => {
+                                      if (!prev) {
+                                        return {
+                                          scrape_options: {
+                                            type: "openapi",
+                                            openapi_schema_url: "",
+                                            openapi_tag: e.currentTarget.value,
+                                          },
+                                        };
+                                      }
+
+                                      return {
+                                        ...prev,
+                                        scrape_options: {
+                                          type: "openapi",
+                                          openapi_schema_url:
+                                            prev.scrape_options
+                                              ?.openapi_schema_url ?? "",
+                                          openapi_tag: e.currentTarget.value,
+                                        },
+                                      };
+                                    })
+                                  }
+                                />
+                              </div>
+                            </Match>
+                          </Switch>
                         </div>
                       </Show>
                     </div>

--- a/frontends/dashboard/src/pages/dataset/CrawlingSettings.tsx
+++ b/frontends/dashboard/src/pages/dataset/CrawlingSettings.tsx
@@ -1,5 +1,5 @@
 import { createMutation, createQuery } from "@tanstack/solid-query";
-import { Show, useContext } from "solid-js";
+import { Show, useContext, createMemo } from "solid-js";
 import { DatasetContext } from "../../contexts/DatasetContext";
 import { useTrieve } from "../../hooks/useTrieve";
 import {
@@ -14,6 +14,7 @@ import { Spacer } from "../../components/Spacer";
 import { UserContext } from "../../contexts/UserContext";
 import { createToast } from "../../components/ShowToasts";
 import { ValidateFn } from "../../utils/validation";
+import { cn } from "shared/utils";
 
 const defaultCrawlOptions: CrawlOptions = {
   boost_titles: false,
@@ -26,6 +27,7 @@ const defaultCrawlOptions: CrawlOptions = {
   max_depth: 10,
   site_url: "",
   openapi_options: null,
+  is_shopify: false,
 };
 
 const normalizeOpenAPIOptions = (
@@ -127,6 +129,8 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
     ReturnType<ValidateFn<CrawlOptions>>["errors"]
   >({});
 
+  const isShopify = createMemo(() => !!options.is_shopify);
+
   const validate: ValidateFn<CrawlOptions> = (value) => {
     const errors: Record<string, string> = {};
     if (!value.site_url) {
@@ -209,17 +213,31 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
       <div class="flex items-center gap-2 py-2 pt-4">
         <label class="block">Boost Titles</label>
         <input
+          checked={options.boost_titles || false}
+          onChange={(e) => {
+            setOptions("boost_titles", e.currentTarget.checked);
+          }}
+          class="h-4 w-4 rounded border border-neutral-300 bg-neutral-100 p-1 accent-magenta-400 dark:border-neutral-900 dark:bg-neutral-800"
+          type="checkbox"
+        />
+        <label class="block pl-4">Shopify</label>
+        <input
+          onChange={(e) => {
+            setOptions("is_shopify", e.currentTarget.checked);
+          }}
+          checked={options.is_shopify || false}
           class="h-4 w-4 rounded border border-neutral-300 bg-neutral-100 p-1 accent-magenta-400 dark:border-neutral-900 dark:bg-neutral-800"
           type="checkbox"
         />
       </div>
 
-      <div class="flex gap-4 pt-2">
+      <div class={cn("flex gap-4 pt-2", isShopify() && "opacity-40")}>
         <div>
           <label class="block" for="">
             Page Limit
           </label>
           <input
+            disabled={isShopify()}
             value={options.limit || "0"}
             onInput={(e) => {
               setOptions("limit", parseInt(e.currentTarget.value));
@@ -234,6 +252,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
             Max Depth
           </label>
           <input
+            disabled={isShopify()}
             value={options.max_depth || "0"}
             onInput={(e) => {
               setOptions("max_depth", parseInt(e.currentTarget.value));
@@ -248,6 +267,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
             OpenAPI Schema URL
           </label>
           <input
+            disabled={isShopify()}
             placeholder="https://example.com/openapi.json"
             value={options.openapi_options?.openapi_schema_url || ""}
             onInput={(e) => {
@@ -269,6 +289,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
             OpenAPI Tag
           </label>
           <input
+            disabled={isShopify()}
             value={options.openapi_options?.openapi_tag || ""}
             onInput={(e) => {
               if (!options.openapi_options) {
@@ -284,10 +305,16 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
           />
         </div>
       </div>
-      <div class="grid w-full grid-cols-2 justify-stretch gap-4 pt-4 xl:grid-cols-4">
+      <div
+        class={cn(
+          "grid w-full grid-cols-2 justify-stretch gap-4 pt-4 xl:grid-cols-4",
+          isShopify() && "opacity-40",
+        )}
+      >
         <div class="">
           <div>Include Paths</div>
           <MultiStringInput
+            disabled={isShopify()}
             placeholder="/docs/*"
             addClass="bg-magenta-100/40 px-2 rounded text-sm border border-magenta-300/40"
             inputClass="w-full"
@@ -302,6 +329,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
         <div class="">
           <div>Exclude Paths</div>
           <MultiStringInput
+            disabled={isShopify()}
             placeholder="/admin/*"
             addClass="bg-magenta-100/40 px-2 text-sm rounded border border-magenta-300/40"
             addLabel="Add Path"
@@ -315,6 +343,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
         <div class="">
           <div>Include Tags</div>
           <MultiStringInput
+            disabled={isShopify()}
             placeholder="h1..."
             addClass="bg-magenta-100/40 text-sm px-2 rounded border border-magenta-300/40"
             addLabel="Add Tag"
@@ -328,6 +357,7 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
         <div class="">
           <div>Exclude Tags</div>
           <MultiStringInput
+            disabled={isShopify()}
             placeholder="button..."
             addClass="bg-magenta-100/40 px-2 text-sm rounded border border-magenta-300/40"
             addLabel="Add Tag"

--- a/frontends/dashboard/src/pages/dataset/CrawlingSettings.tsx
+++ b/frontends/dashboard/src/pages/dataset/CrawlingSettings.tsx
@@ -155,17 +155,20 @@ const RealCrawlingSettings = (props: RealCrawlingSettingsProps) => {
       errors.site_url = "Invalid Site URL - http(s):// required";
     }
 
-    if (!value.limit || value.limit <= 0) {
-      errors.limit = "Limit must be greater than 0";
-    }
-    if (!value.max_depth) {
-      errors.max_depth = "Max depth must be greater than 0";
-    }
-    if (
-      value.scrape_options?.openapi_tag &&
-      !value.scrape_options.openapi_schema_url
-    ) {
-      errors.scrape_options = "OpenAPI Schema URL is required for tag";
+    if (value.scrape_options?.type != "shopify") {
+      if (!value.limit || value.limit <= 0) {
+        errors.limit = "Limit must be greater than 0";
+      }
+      if (!value.max_depth) {
+        errors.max_depth = "Max depth must be greater than 0";
+      }
+      if (
+        value.scrape_options?.type == "openapi" &&
+        value.scrape_options?.openapi_tag &&
+        !value.scrape_options.openapi_schema_url
+      ) {
+        errors.scrape_options = "OpenAPI Schema URL is required for tag";
+      }
     }
 
     return {

--- a/frontends/dashboard/src/utils/validation.tsx
+++ b/frontends/dashboard/src/utils/validation.tsx
@@ -1,15 +1,16 @@
 import { Show } from "solid-js";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ValidateFn<T extends Record<string, any>> = (value: T) => {
-  errors: {
-    [key in keyof T]: string | undefined;
-  };
+export type ValidateFn<T extends Record<string, unknown>> = (value: T) => {
+  errors: ValidateErrors<T>;
   valid: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ValidateErrors<T extends ValidateFn<any>> = ReturnType<T>["errors"];
+export type ValidateErrors<T extends Record<string, any>> = {
+  [key in keyof T]: NonNullable<T[key]> extends Record<string, unknown>
+    ? ReturnType<ValidateFn<NonNullable<T[key]>>>["errors"]
+    : string | undefined;
+};
 
 export const ErrorMsg = (props: { error: string | null | undefined }) => {
   return (

--- a/frontends/shared/ui/MultiStringInput.tsx
+++ b/frontends/shared/ui/MultiStringInput.tsx
@@ -10,6 +10,7 @@ interface MultiStringInputProps {
   addClass?: string;
   addLabel?: string;
   placeholder?: string;
+  disabled?: boolean;
 }
 
 const addBlankStringIfEmpty = (value: string[]) => {
@@ -44,6 +45,7 @@ export const MultiStringInput = (props: MultiStringInputProps) => {
         {(entry) => (
           <div class="flex w-full items-center gap-2">
             <input
+              disabled={props.disabled}
               placeholder={props.placeholder}
               value={entry.value}
               onInput={(e) => {
@@ -56,6 +58,7 @@ export const MultiStringInput = (props: MultiStringInputProps) => {
             />
             <button
               type="button"
+              disabled={props.disabled}
               class="text-neutral-400 hover:text-neutral-500 dark:text-neutral-300 dark:hover:text-neutral-400"
               onClick={() => {
                 if (proxyStore.length === 1) {
@@ -72,6 +75,7 @@ export const MultiStringInput = (props: MultiStringInputProps) => {
       </For>
       <button
         type="button"
+        disabled={props.disabled}
         class={cn("flex gap-2 items-center justify-center", props.addClass)}
         onClick={() => {
           setProxyStore((v) => [

--- a/server/src/bin/crawl-worker.rs
+++ b/server/src/bin/crawl-worker.rs
@@ -17,7 +17,9 @@ use trieve_server::{
     },
 };
 use trieve_server::{
-    data::models::{CrawlRequest, DatasetConfiguration, RedisPool, ScrapeOptions, CrawlShopifyOptions},
+    data::models::{
+        CrawlRequest, CrawlShopifyOptions, DatasetConfiguration, RedisPool, ScrapeOptions,
+    },
     operators::crawl_operator::{get_crawl_from_firecrawl, Status},
 };
 use trieve_server::{
@@ -89,7 +91,11 @@ fn create_chunk_req_payload(
         product.title, variant.title, product.body_html
     );
 
-    let group_variants = if let Some(ScrapeOptions::Shopify(CrawlShopifyOptions{ group_variants: Some(group_variants), .. })) = scrape_request.crawl_options.scrape_options {
+    let group_variants = if let Some(ScrapeOptions::Shopify(CrawlShopifyOptions {
+        group_variants: Some(group_variants),
+        ..
+    })) = scrape_request.crawl_options.scrape_options
+    {
         group_variants
     } else {
         true
@@ -98,7 +104,7 @@ fn create_chunk_req_payload(
     let semantic_boost_phrase = if group_variants {
         variant.title.clone()
     } else {
-        product.title.clone() 
+        product.title.clone()
     };
 
     let fulltext_boost_phrase = if group_variants {
@@ -114,14 +120,12 @@ fn create_chunk_req_payload(
         num_value: variant.price.parse().ok(),
         metadata: serde_json::to_value(product.clone()).ok(),
         tracking_id: if group_variants {
-                Some(variant.id.to_string())
-            } else {
-                Some(product.id.to_string())
-            },
+            Some(variant.id.to_string())
+        } else {
+            Some(product.id.to_string())
+        },
         group_tracking_ids: if group_variants {
-            Some(vec![
-                product.id.to_string()
-            ])
+            Some(vec![product.id.to_string()])
         } else {
             None
         },
@@ -200,7 +204,9 @@ async fn get_chunks_with_firecrawl(
     let mut chunks = vec![];
     let mut spec = None;
 
-    if let Some(ScrapeOptions::OpenApi(openapi_options)) = scrape_request.crawl_options.scrape_options.clone() {
+    if let Some(ScrapeOptions::OpenApi(openapi_options)) =
+        scrape_request.crawl_options.scrape_options.clone()
+    {
         let client = reqwest::Client::new();
 
         let schema = match client
@@ -313,7 +319,9 @@ async fn get_chunks_with_firecrawl(
         let page_tags = get_tags(page_link.clone());
 
         if let Some(spec) = &spec {
-            if let Some(ScrapeOptions::OpenApi(ref openapi_options)) = scrape_request.crawl_options.scrape_options {
+            if let Some(ScrapeOptions::OpenApi(ref openapi_options)) =
+                scrape_request.crawl_options.scrape_options
+            {
                 if page_tags.contains(&openapi_options.openapi_tag) {
                     if let Some(last_tag) = page_tags.last() {
                         // try to find a operation in the spec with an operation_id that matches the last tag directly, with - replaced by _ or vice versa

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6542,6 +6542,7 @@ pub struct CrawlOptions {
     pub boost_titles: Option<bool>,
     /// Options for including an openapi spec in the crawl
     pub openapi_options: Option<CrawlOpenAPIOptions>,
+    pub is_shopify: Option<bool>,
 }
 
 impl CrawlOptions {
@@ -6557,6 +6558,7 @@ impl CrawlOptions {
             max_depth: self.max_depth.or(other.max_depth),
             boost_titles: self.boost_titles.or(other.boost_titles),
             openapi_options: self.openapi_options.clone(),
+            is_shopify: self.is_shopify.or(other.is_shopify),
         }
     }
 }

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6559,7 +6559,7 @@ pub enum ScrapeOptions {
 #[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
 #[schema(title = "CrawlShopifyOptions")]
 pub struct CrawlShopifyOptions {
-    pub boost_item_names: Option<bool>,
+    pub group_variants: Option<bool>,
 }
 
 impl CrawlOptions {

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6541,8 +6541,25 @@ pub struct CrawlOptions {
     /// Boost titles such that keyword matches in titles are prioritized in search results. Strongly recommended to leave this on. Defaults to true.
     pub boost_titles: Option<bool>,
     /// Options for including an openapi spec in the crawl
-    pub openapi_options: Option<CrawlOpenAPIOptions>,
-    pub is_shopify: Option<bool>,
+    pub scrape_options: Option<ScrapeOptions>
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
+#[serde(tag = "type")]
+/// Options for including an openapi spec or shopify settigns
+pub enum ScrapeOptions {
+    /// OpenAPI Scrape Options
+    #[serde(rename = "openapi")]
+    OpenApi(CrawlOpenAPIOptions),
+    /// Shopify Scrape Options
+    #[serde(rename = "shopify")]
+    Shopify(CrawlShopifyOptions)
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
+#[schema(title = "CrawlShopifyOptions")]
+pub struct CrawlShopifyOptions {
+    pub boost_item_names: Option<bool>,
 }
 
 impl CrawlOptions {
@@ -6557,8 +6574,7 @@ impl CrawlOptions {
             exclude_paths: self.exclude_paths.clone().or(other.exclude_paths.clone()),
             max_depth: self.max_depth.or(other.max_depth),
             boost_titles: self.boost_titles.or(other.boost_titles),
-            openapi_options: self.openapi_options.clone(),
-            is_shopify: self.is_shopify.or(other.is_shopify),
+            scrape_options: self.scrape_options.clone(),
         }
     }
 }

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6541,7 +6541,7 @@ pub struct CrawlOptions {
     /// Boost titles such that keyword matches in titles are prioritized in search results. Strongly recommended to leave this on. Defaults to true.
     pub boost_titles: Option<bool>,
     /// Options for including an openapi spec in the crawl
-    pub scrape_options: Option<ScrapeOptions>
+    pub scrape_options: Option<ScrapeOptions>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
@@ -6553,12 +6553,14 @@ pub enum ScrapeOptions {
     OpenApi(CrawlOpenAPIOptions),
     /// Shopify Scrape Options
     #[serde(rename = "shopify")]
-    Shopify(CrawlShopifyOptions)
+    Shopify(CrawlShopifyOptions),
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
 #[schema(title = "CrawlShopifyOptions")]
+/// Options for Crawling Shopify
 pub struct CrawlShopifyOptions {
+    /// This option will ingest all variants as individual chunks and place them in groups by product id. Turning this off will only scrape 1 variant per product. default: true
     pub group_variants: Option<bool>,
 }
 

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -2725,6 +2725,7 @@ pub fn check_completion_param_validity(
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
 /// Options for including an openapi spec in the crawl
+#[schema(title = "CrawlOpenAPIOptions")]
 pub struct CrawlOpenAPIOptions {
     /// OpenAPI json schema to be processed alongside the site crawl
     pub openapi_schema_url: String,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -342,6 +342,8 @@ impl Modify for SecurityAddon {
             data::models::DatasetConfigurationDTO,
             handlers::chunk_handler::CrawlOpenAPIOptions,
             handlers::chunk_handler::CrawlInterval,
+            data::models::ScrapeOptions,
+            data::models::CrawlShopifyOptions,
             handlers::analytics_handler::GetTopDatasetsRequestBody,
             handlers::analytics_handler::CTRDataRequestBody,
             data::models::CTRType,

--- a/server/src/operators/crawl_operator.rs
+++ b/server/src/operators/crawl_operator.rs
@@ -4,7 +4,7 @@ use crate::data::models::FirecrawlCrawlRequest;
 use crate::data::models::RedisPool;
 use crate::handlers::chunk_handler::CrawlInterval;
 use crate::{
-    data::models::{CrawlRequest, CrawlRequestPG, ScrapeOptions, CrawlShopifyOptions, Pool},
+    data::models::{CrawlRequest, CrawlRequestPG, Pool, ScrapeOptions},
     errors::ServiceError,
 };
 use actix_web::web;
@@ -127,7 +127,7 @@ pub async fn crawl(
     redis_pool: web::Data<RedisPool>,
     dataset_id: uuid::Uuid,
 ) -> Result<uuid::Uuid, ServiceError> {
-   let scrape_id = if let Some(ScrapeOptions::Shopify(_)) = crawl_options.scrape_options {
+    let scrape_id = if let Some(ScrapeOptions::Shopify(_)) = crawl_options.scrape_options {
         uuid::Uuid::nil()
     } else {
         crawl_site(crawl_options.clone())
@@ -384,12 +384,13 @@ pub async fn update_crawl_settings_for_dataset(
     }
 
     let merged_options = if let Some(prev_crawl_req) = prev_crawl_req {
-        let previous_crawl_options: CrawlOptions = serde_json::from_value(prev_crawl_req.crawl_options).map_err(|e| ServiceError::InternalServerError(e.to_string()))?;
+        let previous_crawl_options: CrawlOptions =
+            serde_json::from_value(prev_crawl_req.crawl_options)
+                .map_err(|e| ServiceError::InternalServerError(e.to_string()))?;
         crawl_options.merge(previous_crawl_options)
     } else {
         crawl_options
     };
-
 
     diesel::update(
         crawl_requests_table::crawl_requests

--- a/server/src/operators/crawl_operator.rs
+++ b/server/src/operators/crawl_operator.rs
@@ -127,9 +127,13 @@ pub async fn crawl(
     redis_pool: web::Data<RedisPool>,
     dataset_id: uuid::Uuid,
 ) -> Result<uuid::Uuid, ServiceError> {
-    let scrape_id = crawl_site(crawl_options.clone())
-        .await
-        .map_err(|err| ServiceError::BadRequest(format!("Could not crawl site: {}", err)))?;
+   let scrape_id = if crawl_options.is_shopify.unwrap_or(false) {
+        uuid::Uuid::nil()
+    } else {
+        crawl_site(crawl_options.clone())
+            .await
+            .map_err(|err| ServiceError::BadRequest(format!("Could not crawl site: {}", err)))?
+    };
 
     create_crawl_request(crawl_options, dataset_id, scrape_id, pool, redis_pool).await?;
 


### PR DESCRIPTION
# Add Option for scraping any shopify store

- [X] refactor openapi_options to a more generic `scraping_options` enum
- [X] add parameter to ScrapingOptions::Shopify for `group_variants`. This option:
    - ingests all variants with `tracking_id` being `variant.id`
    - places all variants in a `group` based on `product.id`
    - applies `fulltext` and `semantic` boosts based on `variant_title`
- [ ] redoc isn't properly formatting the `ScrapeOptions` enum, but `localhost:8090/swagger-ui` is want to merge to see if mintlify will pick it up. If not will make an issue
- [x] resolve ts-errors

I need help making the ts-errors go away. 🙏

Will rebase and squash commits after everything is confirmed to work.

Tested on:
- https://dudeperfect.store
- https://rugsusa.com