### PR TITLE
bugfix: bump openai dive to a version that doesn't unwrap on requests

### DIFF
--- a/clients/search-component/src/utils/hooks/useKeyboardNavigation.ts
+++ b/clients/search-component/src/utils/hooks/useKeyboardNavigation.ts
@@ -19,9 +19,9 @@ export const useKeyboardNavigation = () => {
       }
     }
 
-    if (e.code === "ArrowDown" && inputRef.current === document.activeElement) {
-      document.getElementById(`trieve-search-item-0`)?.focus();
-    }
+    // if (e.code === "ArrowDown" && inputRef.current === document.activeElement) {
+    //   document.getElementById(`trieve-search-item-0`)?.focus();
+    // }
   };
 
   useEffect(() => {
@@ -34,17 +34,17 @@ export const useKeyboardNavigation = () => {
   const onUpOrDownClicked = (index: number, code: string) => {
     if (code === "ArrowDown") {
       if (index < results.length - 1) {
-        document.getElementById(`trieve-search-item-${index + 1}`)?.focus();
+        // document.getElementById(`trieve-search-item-${index + 1}`)?.focus();
       } else {
-        document.getElementById(`trieve-search-item-0`)?.focus();
+        // document.getElementById(`trieve-search-item-0`)?.focus();
       }
     }
 
     if (code === "ArrowUp") {
       if (index > 0) {
-        document.getElementById(`trieve-search-item-${index - 1}`)?.focus();
+        // document.getElementById(`trieve-search-item-${index - 1}`)?.focus();
       } else {
-        inputRef.current?.focus();
+        // inputRef.current?.focus();
       }
     }
   };

--- a/clients/search-component/src/utils/hooks/useKeyboardNavigation.ts
+++ b/clients/search-component/src/utils/hooks/useKeyboardNavigation.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useModalState } from "./modal-context";
 
 export const useKeyboardNavigation = () => {
-  const { results, setOpen, inputRef, props, open } = useModalState();
+  const { results, setOpen, props, open } = useModalState();
 
   const keyCombo = props.openKeyCombination || [{ ctrl: true }, { key: "k" }];
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -832,6 +832,9 @@ name = "bytes"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -3173,9 +3176,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openai_dive"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c93bf882430365daf501d12578358247e8138f2ba7b03f616986287f2b63cc"
+version = "0.6.3"
+source = "git+https://github.com/devflowinc/openai-client.git?branch=bugfix/parallel-tool-calls-public#3063114f48ac17e0648f7e3c77a6fa2356ae1de9"
 dependencies = [
  "bytes",
  "derive_builder",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -107,7 +107,7 @@ time = { version = "0.3" }
 uuid = { version = "1", features = ["v4", "serde"] }
 diesel_migrations = { version = "2.0" }
 regex = "1.7.3"
-openai_dive = { version = "0.5", features = ["stream"] }
+openai_dive = { git = "https://github.com/devflowinc/openai-client.git", branch = "bugfix/parallel-tool-calls-public", features = ["stream"] }
 tokio = { version = "1.27.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.12"
 futures-util = "0.3.28"

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -206,7 +206,7 @@ impl From<Message> for ChatMessage {
                 refusal: None,
                 tool_calls: None,
                 name: None,
-            }
+            },
         }
     }
 }
@@ -245,7 +245,7 @@ impl From<ChatMessageProxy> for ChatMessage {
                 refusal: None,
                 tool_calls: None,
                 name: None,
-            }
+            },
         }
     }
 }


### PR DESCRIPTION
Bupmed openai_dive, they released a new version with a lot of breaking changes, but this doesn't unwrap when a request fails now it returns an error

When I migrated some parts of the code broke. Things left for PR to be ready for review


Test Ingestion
- [X] Ingest dense vectors

Test Search UI
- [X] Search with dense vectors
- [x] RAG on specific chunks with streaming
- [x] RAG on specific chunks w/out streaming
- [x] suggested queries

Test ChatUI
- [x] Regenrate message
- [x] Edit message (patch)
- [x] Create message

etc.
- [x] Suggested queries route
