### PR TITLE
fix: request `profile` and `email` scopes

### DIFF
--- a/server/src/handlers/auth_handler.rs
+++ b/server/src/handlers/auth_handler.rs
@@ -334,7 +334,10 @@ pub async fn login(
             CsrfToken::new_random,
             Nonce::new_random,
         )
-        .add_scope(Scope::new("openid".to_string()))
+        .add_scopes([
+            Scope::new("profile".to_owned()),
+            Scope::new("email".to_owned()),
+        ])
         .set_pkce_challenge(pkce_challenge)
         .url();
 


### PR DESCRIPTION
Trieve expects `name` and `email` claims. Per [OpenID Connect specification][oidc], these are made available with `profile` and `email` scopes correspondingly.

[oidc]: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims