### PR TITLE
fix: remove `session_state` parameter

### DIFF
--- a/server/src/handlers/auth_handler.rs
+++ b/server/src/handlers/auth_handler.rs
@@ -35,7 +35,6 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Deserialize, Debug)]
 pub struct OpCallback {
     pub state: String,
-    pub session_state: String,
     pub code: String,
 }
 


### PR DESCRIPTION
This parameter is not used by Trieve and is not a part of the [OpenID Connect spec][oidc], which makes Trieve break when used with OIDC providers that are not Keycloak.

[oidc]: https://openid.net/specs/openid-connect-core-1_0.html
