### PR TITLE
fix(fumadocs): move trieve-ts-sdk to peerDeps, loosen version range

### DIFF
--- a/clients/trieve-fumadocs-adapter/package.json
+++ b/clients/trieve-fumadocs-adapter/package.json
@@ -34,8 +34,10 @@
     "fumadocs-ui": "^14.1.0",
     "next": "14.2.4",
     "react": "^18",
-    "react-dom": "^18",
-    "trieve-ts-sdk": "^0.0.14"
+    "react-dom": "^18"
+  },
+  "peerDependencies": {
+    "trieve-ts-sdk": ">= 0.0.14"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant

`^0.0.14` does not match the most recent trieve-ts-sdk version `0.0.15` (since the leftmost non-0 number is different)