### PR TITLE
feature: add errors into prometheus /metrics scrape

### DIFF
--- a/server/src/handlers/auth_handler.rs
+++ b/server/src/handlers/auth_handler.rs
@@ -1,7 +1,6 @@
 use crate::data::models::{Organization, RedisPool, StripePlan, UserRole};
 use crate::get_env;
 use crate::operators::dittofeed_operator::{get_user_ditto_identity, send_user_ditto_identity};
-use crate::operators::email_operator::send_email;
 use crate::operators::invitation_operator::check_inv_valid;
 use crate::operators::organization_operator::{get_org_from_id_query, get_user_org_count};
 use crate::operators::user_operator::{
@@ -16,9 +15,6 @@ use crate::{
 };
 use actix_identity::Identity;
 use actix_session::Session;
-use actix_web::body::MessageBody;
-use actix_web::dev::{ServiceRequest, ServiceResponse};
-use actix_web::middleware::Next;
 use actix_web::{
     dev::Payload, web, Error, FromRequest, HttpMessage as _, HttpRequest, HttpResponse,
 };
@@ -35,49 +31,6 @@ use serde_json::json;
 use std::fs::read_to_string;
 use std::future::{ready, Ready};
 use utoipa::{IntoParams, ToSchema};
-
-pub async fn timeout_15secs(
-    service_req: ServiceRequest,
-    next: Next<impl MessageBody + 'static>,
-) -> Result<ServiceResponse<impl MessageBody>, Error> {
-    let path = service_req.path().to_string();
-    let method = service_req.method().as_str().to_string();
-    let queries = service_req.query_string().to_string();
-    let headers = service_req
-        .headers()
-        .iter()
-        .filter_map(|(k, v)| {
-            if k.to_string().to_lowercase() == "authorization" {
-                None
-            } else {
-                format!("{}: {}", k, v.to_str().unwrap()).into()
-            }
-        })
-        .collect::<Vec<String>>();
-
-    let base_server_url =
-        std::env::var("BASE_SERVER_URL").unwrap_or_else(|_| "https://api.trieve.ai".to_string());
-
-    match tokio::time::timeout(std::time::Duration::from_secs(15), next.call(service_req)).await {
-        Ok(res) => res,
-        Err(_err) => {
-            let email_body = format!(
-                "Request timeout: {}\n\n<br/><br/>Method: {}\n<br/><br/>Queries: {}\n<br/><br/>Headers: {:?}",
-                path, method, queries, headers
-            );
-            log::info!("Request timeout: {}", path);
-            let _ = send_email(
-                email_body,
-                "webmaster@trieve.ai".to_string(),
-                Some(format!(
-                    "🤖🤖 {} Request timeout {} 🤖🤖",
-                    base_server_url, path
-                )),
-            );
-            Err(actix_web::error::ErrorRequestTimeout("Trieve is currently under extended load and we are working to autoscale. If you continue facing this issue, please send an email to humans@trieve.ai with 'request timeout' in the subject line and we will get back to you as soon as possible.".to_string()))
-        }
-    }
-}
 
 #[derive(Deserialize, Debug)]
 pub struct OpCallback {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -28,7 +28,6 @@ use diesel_async::pooled_connection::ManagerConfig;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
-use handlers::auth_handler::timeout_15secs;
 use minijinja::Environment;
 use openssl::ssl::SslVerifyMode;
 use openssl::ssl::{SslConnector, SslMethod};
@@ -714,7 +713,8 @@ pub fn main() -> std::io::Result<()> {
                 .app_data(web::Data::new(clickhouse_client.clone()))
                 .app_data(web::Data::new(metrics.clone()))
                 .wrap(sentry_actix::Sentry::new())
-                .wrap(from_fn(timeout_15secs))
+                .wrap(from_fn(middleware::timeout_middleware::timeout_15secs))
+                .wrap(from_fn(middleware::metrics_middleware::error_logging_middleware))
                 .wrap(middleware::api_version::ApiVersionCheckFactory)
                 .wrap(middleware::auth_middleware::AuthMiddlewareFactory)
                 .wrap(

--- a/server/src/middleware/metrics_middleware.rs
+++ b/server/src/middleware/metrics_middleware.rs
@@ -1,0 +1,27 @@
+use crate::handlers::metrics_handler::Metrics;
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    middleware::Next,
+    web,
+};
+
+pub async fn error_logging_middleware(
+    metrics: web::Data<Metrics>,
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let path = req.path().to_string();
+    let method = req.method().to_string();
+    let base_server_url =
+        std::env::var("BASE_SERVER_URL").unwrap_or_else(|_| "https://api.trieve.ai".to_string());
+
+    let response = next.call(req).await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        metrics.register_error(status.as_u16(), method, path, base_server_url);
+    }
+
+    Ok(response)
+}

--- a/server/src/middleware/mod.rs
+++ b/server/src/middleware/mod.rs
@@ -1,3 +1,5 @@
 pub mod api_version;
 pub mod auth_middleware;
 pub mod json_middleware;
+pub mod metrics_middleware;
+pub mod timeout_middleware;

--- a/server/src/middleware/timeout_middleware.rs
+++ b/server/src/middleware/timeout_middleware.rs
@@ -1,0 +1,49 @@
+use crate::operators::email_operator::send_email;
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    middleware::Next,
+};
+
+pub async fn timeout_15secs(
+    service_req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let path = service_req.path().to_string();
+    let method = service_req.method().as_str().to_string();
+    let queries = service_req.query_string().to_string();
+    let headers = service_req
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| {
+            if k.to_string().to_lowercase() == "authorization" {
+                None
+            } else {
+                format!("{}: {}", k, v.to_str().unwrap()).into()
+            }
+        })
+        .collect::<Vec<String>>();
+
+    let base_server_url =
+        std::env::var("BASE_SERVER_URL").unwrap_or_else(|_| "https://api.trieve.ai".to_string());
+
+    match tokio::time::timeout(std::time::Duration::from_secs(15), next.call(service_req)).await {
+        Ok(res) => res,
+        Err(_err) => {
+            let email_body = format!(
+                "Request timeout: {}\n\n<br/><br/>Method: {}\n<br/><br/>Queries: {}\n<br/><br/>Headers: {:?}",
+                path, method, queries, headers
+            );
+            log::info!("Request timeout: {}", path);
+            let _ = send_email(
+                email_body,
+                "webmaster@trieve.ai".to_string(),
+                Some(format!(
+                    "🤖🤖 {} Request timeout {} 🤖🤖",
+                    base_server_url, path
+                )),
+            );
+            Err(actix_web::error::ErrorRequestTimeout("Trieve is currently under extended load and we are working to autoscale. If you continue facing this issue, please send an email to humans@trieve.ai with 'request timeout' in the subject line and we will get back to you as soon as possible.".to_string()))
+        }
+    }
+}


### PR DESCRIPTION
Adds error gauge for errors with the error type into prometheus scrape.

Example output:
```
# HELP tr_api_errors number of errors
# TYPE tr_api_errors gauge
tr_api_errors{error_code="303",method="GET",route="/api/auth"} 1
tr_api_errors{error_code="401",method="GET",route="/api/auth/me"} 1
tr_api_errors{error_code="401",method="GET",route="/metrics"} 1
```