### PR TITLE
bugfix: use correct page count, feature: fileworker integration with Trieve

### DIFF
--- a/.env.server
+++ b/.env.server
@@ -47,3 +47,4 @@ RUST_LOG="INFO"
 BM25_ACTIVE="true"
 FIRECRAWL_URL=https://api.firecrawl.dev 
 FIRECRAWL_API_KEY=fc-abdef**************
+PDF2MD_URL="http://localhost:8081"

--- a/pdf2md/server/src/lib.rs
+++ b/pdf2md/server/src/lib.rs
@@ -1,5 +1,8 @@
 use actix_web::{
-    get, middleware::Logger, web::{self, PayloadConfig}, App, HttpResponse, HttpServer
+    get,
+    middleware::Logger,
+    web::{self, PayloadConfig},
+    App, HttpResponse, HttpServer,
 };
 use chm::tools::migrations::{run_pending_migrations, SetupArgs};
 use errors::{custom_json_error_handler, ErrorResponseBody};
@@ -47,6 +50,7 @@ macro_rules! get_env {
         ENV_VAR.as_str()
     }};
 }
+
 #[macro_export]
 #[cfg(feature = "runtime-env")]
 macro_rules! get_env {
@@ -79,8 +83,7 @@ pub async fn main() -> std::io::Result<()> {
             name = "BSL",
             url = "https://github.com/devflowinc/trieve/blob/main/LICENSE.txt",
         ),
-        version = "0.0.0",
-    ), 
+        version = "0.0.0"), 
     modifiers(&SecurityAddon),
     tags(
         (name = "Task", description = "Task operations. Allow you to interact with tasks."),
@@ -166,27 +169,19 @@ pub async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(jinja_env))
             .app_data(web::Data::new(redis_pool.clone()))
             .app_data(web::Data::new(clickhouse_client.clone()))
-            .service(
-                utoipa_actix_web::scope("/api/task").configure(|config| {
-                    config.service(create_task).service(get_task);
-                }),
-            )
-            .service(
-                utoipa_actix_web::scope("/static").configure(|config| {
-                    config.service(jinja_templates::static_files);
-                }),
-            )
-            .service(
-                utoipa_actix_web::scope("/health").configure(|config| {
-                    config.service(health_check);
-                }),
-            )
+            .service(utoipa_actix_web::scope("/api/task").configure(|config| {
+                config.service(create_task).service(get_task);
+            }))
+            .service(utoipa_actix_web::scope("/static").configure(|config| {
+                config.service(jinja_templates::static_files);
+            }))
+            .service(utoipa_actix_web::scope("/health").configure(|config| {
+                config.service(health_check);
+            }))
             .openapi_service(|api| Redoc::with_url("/redoc", api))
-            .service(
-                utoipa_actix_web::scope("").configure(|config| {
-                    config.service(jinja_templates::public_page);
-                }),
-            )
+            .service(utoipa_actix_web::scope("").configure(|config| {
+                config.service(jinja_templates::public_page);
+            }))
             .into_app()
     })
     .bind(("127.0.0.1", 8081))?

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -90,7 +90,7 @@ async-stripe = { version = "0.37.1", features = [
     "billing",
 ] }
 chrono = { version = "0.4.20", features = ["serde"] }
-derive_more = { version = "0.99.7" }
+derive_more = { version = "0.99.7", features = ["display"] }
 diesel = { version = "2", features = [
     "uuid",
     "chrono",

--- a/server/src/bin/file-worker.rs
+++ b/server/src/bin/file-worker.rs
@@ -369,7 +369,7 @@ async fn upload_file(
         });
 
         let pdf2md_response = pdf2md_client
-            .post(format!("{}/api/task/create", pdf2md_url))
+            .post(format!("{}/api/task", pdf2md_url))
             .header("Content-Type", "application/json")
             .header("Authorization", &pdf2md_auth)
             .json(&json_value)

--- a/server/src/bin/file-worker.rs
+++ b/server/src/bin/file-worker.rs
@@ -252,7 +252,7 @@ async fn file_worker(
                     .query_async::<redis::aio::MultiplexedConnection, usize>(&mut *redis_connection)
                     .await;
             }
-            Ok(None) => {
+            Ok(_) => {
                 log::info!(
                     "File was uploaded with specification to not create chunks for it: {:?}",
                     file_worker_message.file_id

--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -11,8 +11,7 @@ use crate::{
     middleware::auth_middleware::verify_member,
     operators::{
         file_operator::{
-            delete_file_query, get_aws_bucket, get_dataset_file_query,
-            get_file_query,
+            delete_file_query, get_aws_bucket, get_dataset_file_query, get_file_query,
         },
         organization_operator::get_file_size_sum_org,
     },

--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -11,7 +11,7 @@ use crate::{
     middleware::auth_middleware::verify_member,
     operators::{
         file_operator::{
-            create_file_query, delete_file_query, get_aws_bucket, get_dataset_file_query,
+            delete_file_query, get_aws_bucket, get_dataset_file_query,
             get_file_query,
         },
         organization_operator::get_file_size_sum_org,

--- a/server/src/handlers/file_handler.rs
+++ b/server/src/handlers/file_handler.rs
@@ -182,17 +182,6 @@ pub async fn upload_file_handler(
 
     bucket_upload_span.finish();
 
-    let file_size_mb = (decoded_file_data.len() as f64 / 1024.0 / 1024.0).round() as i64;
-
-    create_file_query(
-        file_id,
-        file_size_mb,
-        upload_file_data.clone(),
-        dataset_org_plan_sub.dataset.id,
-        pool.clone(),
-    )
-    .await?;
-
     let message = FileWorkerMessage {
         file_id,
         dataset_id: dataset_org_plan_sub.dataset.id,

--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -94,9 +94,7 @@ pub async fn create_file_query(
         .values(&new_file)
         .get_result(&mut conn)
         .await
-        .map_err(|err| {
-            ServiceError::BadRequest(format!("Could not create file {:?}", err))
-        })?;
+        .map_err(|err| ServiceError::BadRequest(format!("Could not create file {:?}", err)))?;
 
     Ok(created_file)
 }
@@ -108,7 +106,8 @@ pub fn preprocess_file_to_chunks(
 ) -> Result<Vec<String>, ServiceError> {
     let file_text = convert_html_to_text(&html_content);
 
-    let split_regex: Option<Regex> = upload_file_data.split_delimiters
+    let split_regex: Option<Regex> = upload_file_data
+        .split_delimiters
         .map(|delimiters| {
             build_chunking_regex(delimiters).map_err(|e| {
                 log::error!("Could not parse chunking delimiters {:?}", e);
@@ -141,7 +140,6 @@ pub async fn create_file_chunks(
     event_queue: web::Data<EventQueue>,
     mut redis_conn: MultiplexedConnection,
 ) -> Result<(), ServiceError> {
-
     let mut chunks: Vec<ChunkReqPayload> = [].to_vec();
 
     let name = format!("{}", upload_file_data.file_name);

--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -94,7 +94,9 @@ pub async fn create_file_query(
         .values(&new_file)
         .get_result(&mut conn)
         .await
-        .map_err(|_| ServiceError::BadRequest("Could not create file, try again".to_string()))?;
+        .map_err(|err| {
+            ServiceError::BadRequest(format!("Could not create file {:?}", err))
+        })?;
 
     Ok(created_file)
 }


### PR DESCRIPTION
This supports the full end to end workflow of uploading a document, having it be chunked by pdf2md service, and having it be viewable in the Trieve Dashboard.

Currently only uses 1 chunk per page.