### PR TITLE
docs: docker compose guide with fixed docker containers

### DIFF
--- a/pdf2md/.env.dist
+++ b/pdf2md/.env.dist
@@ -20,7 +20,7 @@ MINIO_ROOT_PASSWORD=rootpassword
 
 # PDF2MD conversion worker services
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_API_KEY=
+LLM_API_KEY=sk-*********************
 LLM_MODEL=gpt-4o-mini
 
 # PDF2MD HTTP API server

--- a/pdf2md/README.md
+++ b/pdf2md/README.md
@@ -1,0 +1,89 @@
+# Contributing to PDF2MD
+
+## Project Setup
+
+### Setup ENV's
+
+```bash
+cd server
+cp .env.dist .env
+```
+
+### Start docker dependency services
+
+- redis
+- s3
+- clickhouse-db
+
+```bash
+docker compose up -d
+```
+
+### Run Server + Workers
+
+Strongly recommend using tmux or another multiplex system to handle the different proceses.
+
+```bash
+cargo watch -x run #HTTP server
+cargo run --bin supervisor-worker
+cargo run --bin chunk-worker
+```
+
+### Run tailwindcss server for demo UI
+
+```
+npx tailwindcss -i ./static/in.css -o ./static/output.css --watch
+```
+
+### Testing using the CLI
+
+Make your changes then use the following to run:
+
+```bash
+cd cli
+cargo run -- help #or other command instead of help
+```
+
+## Deploying 
+
+### docker-compose
+
+```bash
+docker compose up -f docker-compose-prod.yaml -d
+```
+
+You can either chose to build locally or pull the pre-built images from the docker hub.
+
+#### Build Options
+##### Build On Machine:
+
+```bash
+docker compose up -f docker-compose-prod.yaml -d --build
+```
+
+##### Use Pre-built Images:
+```bash
+docker compose up -f docker-compose-prod.yaml -d --pull always
+```
+
+#### Setup Caddy reverse proxy (optional)
+
+Setup a Caddyfile with the following content:
+
+```bash
+# Global options
+{
+    email developer@example.com
+}
+
+# Define a site block for pdftomd.example.com
+pdftomd.example.com {
+    reverse_proxy localhost:8081
+}
+```
+
+Start the caddy reverse proxy. This should also handle your ssl
+
+```bash
+sudo systemctl reload caddy.service
+```

--- a/pdf2md/docker-compose-prod.yaml
+++ b/pdf2md/docker-compose-prod.yaml
@@ -1,0 +1,26 @@
+services:
+  pdf2md-server:
+    image: trieve/pdf2md-server:latest
+    network_mode: "host"
+    build:
+      context: ./server/
+      dockerfile: Dockerfile.pdf2md-server
+    env_file: .env
+
+  supervisor-worker:
+    image: trieve/supervisor-worker:latest
+    network_mode: "host"
+    build:
+      context: ./server/
+      dockerfile: Dockerfile.supervisor-worker
+    env_file: .env
+
+  chunk-worker:
+    image: trieve/chunk-worker:latest
+    network_mode: "host"
+    build:
+      context: ./server/
+      dockerfile: Dockerfile.chunk-worker
+    env_file: .env
+    deploy:
+      replicas: 5

--- a/pdf2md/docker-compose-prod.yaml
+++ b/pdf2md/docker-compose-prod.yaml
@@ -1,3 +1,6 @@
+include:
+  - docker-compose.yml  # This includes all services from base file
+
 services:
   pdf2md-server:
     image: trieve/pdf2md-server:latest

--- a/pdf2md/docker-compose.yml
+++ b/pdf2md/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   redis:
     image: redis:7.2.2
-    profiles: ["dev", "prod-deps"]
     restart: always
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
@@ -18,7 +17,6 @@ services:
 
   s3:
     image: minio/minio:RELEASE.2023-09-27T15-22-50Z
-    profiles: ["dev", "prod-deps"]
     ports:
       - 9000:9000
       - 42625:42625
@@ -38,7 +36,6 @@ services:
 
   s3-client:
     image: minio/mc
-    profiles: ["dev", "prod-deps"]
     depends_on:
       s3:
         condition: service_healthy
@@ -59,7 +56,6 @@ services:
 
   clickhouse-db:
     image: trieve/clickhouse:latest
-    profiles: ["dev", "prod-deps"]
     restart: always
     environment:
       - CLICKHOUSE_USER=clickhouse
@@ -73,35 +69,6 @@ services:
       - "9009:9009"
     networks:
       - app-network
-
-  pdf2md-server:
-    image: trieve/pdf2md-server:latest
-    profiles: ["prod"]
-    network_mode: "host"
-    build:
-      context: ./server/
-      dockerfile: Dockerfile.pdf2md-server
-    env_file: .env
-
-  supervisor-worker:
-    image: trieve/supervisor-worker:latest
-    profiles: ["prod"]
-    network_mode: "host"
-    build:
-      context: ./server/
-      dockerfile: Dockerfile.supervisor-worker
-    env_file: .env
-
-  chunk-worker:
-    image: trieve/chunk-worker:latest
-    profiles: ["prod"]
-    network_mode: "host"
-    build:
-      context: ./server/
-      dockerfile: Dockerfile.chunk-worker
-    env_file: .env
-    deploy:
-      replicas: 5
 
 networks:
   app-network:

--- a/pdf2md/server/Dockerfile.chunk-worker
+++ b/pdf2md/server/Dockerfile.chunk-worker
@@ -3,7 +3,7 @@ FROM rust:1.81-slim-bookworm AS chef
 # it will be cached from the second build onwards
 RUN apt-get update -y && apt-get -y install pkg-config libssl-dev g++ curl
 RUN cargo install cargo-chef 
-WORKDIR app
+WORKDIR /app
 
 FROM chef AS planner
 COPY . .
@@ -18,8 +18,16 @@ COPY . .
 RUN cargo build --release --features "runtime-env" --bin "chunk-worker"
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update -y && apt-get -y install pkg-config libssl-dev ca-certificates 
 WORKDIR /app
+
+RUN apt-get update -y; \
+    apt-get install -y \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+        poppler-utils \
+    ;
+
 COPY ./ch_migrations/ /app/ch_migrations
 COPY --from=builder /app/target/release/chunk-worker /app/chunk-worker
 

--- a/pdf2md/server/Dockerfile.pdf2md-server
+++ b/pdf2md/server/Dockerfile.pdf2md-server
@@ -3,7 +3,7 @@ FROM rust:1.81-slim-bookworm AS chef
 # it will be cached from the second build onwards
 RUN apt-get update -y && apt-get -y install pkg-config libssl-dev g++ curl
 RUN cargo install cargo-chef 
-WORKDIR app
+WORKDIR /app
 
 FROM chef AS planner
 COPY . .
@@ -23,12 +23,9 @@ WORKDIR /app
 RUN apt-get update -y; \
     apt-get install -y \
     pkg-config \
-    build-essential\
     libssl-dev \
     ca-certificates \
-    ; \
-    mkdir -p /app/tmp
-
+    ;
 
 COPY ./ch_migrations /app/ch_migrations
 COPY --from=builder /app/static /app/static

--- a/pdf2md/server/Dockerfile.supervisor-worker
+++ b/pdf2md/server/Dockerfile.supervisor-worker
@@ -3,7 +3,7 @@ FROM rust:1.81-slim-bookworm AS chef
 # it will be cached from the second build onwards
 RUN apt-get update -y && apt-get -y install pkg-config libssl-dev g++ curl
 RUN cargo install cargo-chef 
-WORKDIR app
+WORKDIR /app
 
 FROM chef AS planner
 COPY . .
@@ -18,8 +18,15 @@ COPY . .
 RUN cargo build --release --features "runtime-env" --bin "supervisor-worker"
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update -y && apt-get -y install pkg-config libssl-dev ca-certificates 
 WORKDIR /app
+
+RUN apt-get update -y; \
+    apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    ;
+
 COPY ./ch_migrations/ /app/ch_migrations
 COPY --from=builder /app/target/release/supervisor-worker /app/supervisor-worker
 

--- a/pdf2md/server/src/operators/clickhouse.rs
+++ b/pdf2md/server/src/operators/clickhouse.rs
@@ -124,8 +124,6 @@ pub async fn update_task_status(
         }
     };
 
-    log::info!("Update Task Sttaus Query: {}", query);
-
     clickhouse_client
         .query(&query)
         .execute()

--- a/pdf2md/server/src/operators/pdf_chunk.rs
+++ b/pdf2md/server/src/operators/pdf_chunk.rs
@@ -182,12 +182,13 @@ pub async fn chunk_sub_pages(
     clickhouse_client: &clickhouse::Client,
     redis_pool: &RedisPool,
 ) -> Result<Vec<ChunkClickhouse>, ServiceError> {
+    log::info!("Chunking pages for {:?} size {}", task.task_id, data.len());
     let pdf = PDF::from_bytes(data)
-        .map_err(|_| ServiceError::BadRequest("Failed to open PDF file".to_string()))?;
+        .map_err(|err| ServiceError::BadRequest(format!("Failed to open PDF file {:?}", err)))?;
 
     let pages = pdf
         .render(pdf2image::Pages::All, None)
-        .map_err(|_| ServiceError::BadRequest("Failed to render PDF file".to_string()))?;
+        .map_err(|err| ServiceError::BadRequest(format!("Failed to render PDF file {:?}", err)))?;
 
     let mut result_pages = vec![];
 

--- a/pdf2md/server/src/workers/chunk-worker.rs
+++ b/pdf2md/server/src/workers/chunk-worker.rs
@@ -1,4 +1,4 @@
-use chm::tools::migrations::{run_pending_migrations, SetupArgs};
+use chm::tools::migrations::SetupArgs;
 use pdf2md_server::{
     errors::ServiceError,
     get_env,
@@ -51,10 +51,6 @@ async fn main() {
         .with_database(args.database.as_ref().unwrap())
         .with_option("async_insert", "1")
         .with_option("wait_for_async_insert", "0");
-
-    let _ = run_pending_migrations(args.clone()).await.map_err(|err| {
-        log::error!("Failed to run clickhouse migrations: {:?}", err);
-    });
 
     let should_terminate = Arc::new(AtomicBool::new(false));
     signal_hook::flag::register(SIGTERM, Arc::clone(&should_terminate))

--- a/pdf2md/server/src/workers/supervisor-worker.rs
+++ b/pdf2md/server/src/workers/supervisor-worker.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use chm::tools::migrations::{run_pending_migrations, SetupArgs};
+use chm::tools::migrations::SetupArgs;
 use lopdf::{Document, Object, ObjectId};
 use pdf2md_server::{
     errors::ServiceError,
@@ -56,10 +56,6 @@ async fn main() {
         .with_database(args.database.as_ref().unwrap())
         .with_option("async_insert", "1")
         .with_option("wait_for_async_insert", "0");
-
-    let _ = run_pending_migrations(args.clone()).await.map_err(|err| {
-        log::error!("Failed to run clickhouse migrations: {:?}", err);
-    });
 
     let should_terminate = Arc::new(AtomicBool::new(false));
     signal_hook::flag::register(SIGTERM, Arc::clone(&should_terminate))


### PR DESCRIPTION
- **chore: create seperate docker-compose.yml files for dev and prod**
- **bugfix: make Dockerfile.worker to install poppler**
- **feature: don't let workers run migrations**
- **docs: setup README with setup guide and hosting guide**