### PR TITLE
bugfix: revert failed inserts in qdrant_only mode

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update stable
+      - run: rustup update 1.81
+      - run: rustup default 1.81
+      - run: rustup component add rustfmt
       - name: Cargo fmt
         run: cargo fmt --manifest-path=./server/Cargo.toml -- --check
 
@@ -30,8 +32,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup update 1.81
+      - run: rustup default 1.81
       - run: rustup component add clippy
-      - run: rustup update stable
       - uses: clechasseur/rs-clippy-check@v3
         with:
           args: --features runtime-env --manifest-path server/Cargo.toml -- -D clippy::print_stdout -D warnings
@@ -56,7 +59,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: rustup update stable
+      - run: rustup update 1.81
+      - run: rustup default 1.81
       - name: Installing Vaccum
         run: npm install -g @quobix/vacuum
       - name: Generating OpenAPI spec

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -348,9 +348,6 @@ pub async fn create_chunk(
         .into());
     }
 
-    let dataset_config =
-        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration.clone());
-
     let chunks = chunks.into_iter().map(|chunk| {
         let non_empty_tracking_id = chunk
             .tracking_id
@@ -368,18 +365,12 @@ pub async fn create_chunk(
     let (non_upsert_chunk_ingestion_message, non_upsert_chunk_metadatas) = create_chunk_metadata(
         non_upsert_chunks,
         dataset_org_plan_sub.dataset.id,
-        dataset_config.clone(),
         pool.clone(),
     )
     .await?;
 
-    let (upsert_chunk_ingestion_message, upsert_chunk_metadatas) = create_chunk_metadata(
-        upsert_chunks,
-        dataset_org_plan_sub.dataset.id,
-        dataset_config.clone(),
-        pool.clone(),
-    )
-    .await?;
+    let (upsert_chunk_ingestion_message, upsert_chunk_metadatas) =
+        create_chunk_metadata(upsert_chunks, dataset_org_plan_sub.dataset.id, pool.clone()).await?;
 
     let chunk_metadatas = non_upsert_chunk_metadatas
         .clone()

--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -2429,7 +2429,6 @@ pub async fn get_row_count_for_organization_id_query(
 pub async fn create_chunk_metadata(
     chunks: Vec<ChunkReqPayload>,
     dataset_uuid: uuid::Uuid,
-    _dataset_configuration: DatasetConfiguration,
     pool: web::Data<Pool>,
 ) -> Result<(BulkUploadIngestionMessage, Vec<ChunkMetadata>), ServiceError> {
     let mut ingestion_messages = vec![];

--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -219,9 +219,6 @@ pub async fn create_file_chunks(
         ));
     }
 
-    let dataset_config =
-        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration);
-
     let chunk_segments = chunks
         .chunks(120)
         .map(|chunk_segment| chunk_segment.to_vec())
@@ -230,13 +227,9 @@ pub async fn create_file_chunks(
     let mut serialized_messages: Vec<String> = vec![];
 
     for chunk_segment in chunk_segments {
-        let (ingestion_message, _) = create_chunk_metadata(
-            chunk_segment,
-            dataset_org_plan_sub.dataset.id,
-            dataset_config.clone(),
-            pool.clone(),
-        )
-        .await?;
+        let (ingestion_message, _) =
+            create_chunk_metadata(chunk_segment, dataset_org_plan_sub.dataset.id, pool.clone())
+                .await?;
 
         let serialized_message: String =
             serde_json::to_string(&ingestion_message).map_err(|_| {

--- a/server/src/operators/webhook_operator.rs
+++ b/server/src/operators/webhook_operator.rs
@@ -49,18 +49,8 @@ pub async fn publish_content<T: Into<ChunkReqPayload>>(
 ) -> Result<(), ServiceError> {
     let chunk: ChunkReqPayload = value.into();
 
-    let full_dataset =
-        get_dataset_by_id_query(UnifiedId::TrieveUuid(dataset_id), pool.clone()).await?;
-
-    let dataset_config = DatasetConfiguration::from_json(full_dataset.server_configuration.clone());
-
-    let (upsert_message, _) = create_chunk_metadata(
-        vec![chunk.clone()],
-        dataset_id,
-        dataset_config,
-        pool.clone(),
-    )
-    .await?;
+    let (upsert_message, _) =
+        create_chunk_metadata(vec![chunk.clone()], dataset_id, pool.clone()).await?;
 
     let mut redis_conn = redis_pool
         .get()


### PR DESCRIPTION
Refactored the logic here to handle the error case and the updating dataset count's seperately