### PR TITLE
styling: fix overflowing analytics table

### DIFF
--- a/frontends/dashboard/src/analytics/components/charts/Card.tsx
+++ b/frontends/dashboard/src/analytics/components/charts/Card.tsx
@@ -18,7 +18,7 @@ export const Card = (props: CardProps) => {
         "grid-column": `span ${props.width} / span ${props.width}`,
       }}
       class={cn(
-        "rounded-md border border-neutral-300 bg-white p-4 shadow-sm",
+        "overflow-x-auto rounded-md border border-neutral-300 bg-white p-4 shadow-sm",
         classStuff.class,
       )}
     >

--- a/frontends/dashboard/src/analytics/pages/SearchAnalyticsPage.tsx
+++ b/frontends/dashboard/src/analytics/pages/SearchAnalyticsPage.tsx
@@ -51,12 +51,12 @@ export const SearchAnalyticsPage = () => {
 
         <LowConfidenceQueries width={1} params={analyticsFilters} />
 
-        <CTRSearchQueries width={1} params={analyticsFilters} />
+        <CTRSearchQueries width={2} params={analyticsFilters} />
         <Card
           class="flex flex-col justify-between px-4"
           title="No Result Queries"
           subtitle="Searches with no results"
-          width={1}
+          width={2}
         >
           <NoResultQueries params={analyticsFilters} />
         </Card>


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
![image](https://github.com/user-attachments/assets/a40e7f62-6997-4eb2-8e07-86cff2913f86)
added an overflow to all cards but also made the specific table 2 cols wide since we added more data to it. 