### PR TITLE
fix: trieve-fern-adapter workflow

### DIFF
--- a/.github/workflows/update-trieve-fern-adapter.yaml
+++ b/.github/workflows/update-trieve-fern-adapter.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       
     steps:
       - name: Checkout repository
@@ -41,19 +42,32 @@ jobs:
         working-directory: ./clients/trieve-fern-adapter
         run: yarn install --frozen-lockfile
       
-      - name: Bump version
+      - name: Create version bump branch
         working-directory: ./clients/trieve-fern-adapter
         run: |
-          git pull origin main
           yarn version --patch --no-git-tag-version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          BRANCH_NAME="trieve-fern-adapter/v${CURRENT_VERSION}"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b $BRANCH_NAME
           git add package.json
-          git commit -m "chore: bump trieve-fern-adapter version to $(node -p "require('./package.json').version")"
-      
-      - name: Push changes
-        working-directory: ./clients/trieve-fern-adapter
+          git commit -m "chore: bump trieve-fern-adapter version to ${CURRENT_VERSION}"
+          git push origin $BRANCH_NAME
+
+      - name: Create Pull Request
         run: |
-          git push origin main
-      
+          gh pr create \
+            --title "chore: bump trieve-fern-adapter v${{ env.CURRENT_VERSION }}" \
+            --body "This PR was automatically created by the release workflow.
+
+            Changes:
+            - Bumps trieve-fern-adapter version to ${{ env.CURRENT_VERSION }}" \
+            --base main \
+            --head ${{ env.BRANCH_NAME }} \
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
         working-directory: ./clients/trieve-fern-adapter
         run: yarn publish


### PR DESCRIPTION
I notice the `update-trieve-fern-adapter` workflow is not working as the `main` branch is branch protected. Instead of committing to `main`, this will create a new PR with the version bump.