### PR TITLE
chore: prevent trieve-fern-adapter workflow running when merging the bump pr

### DIFF
--- a/.github/workflows/update-trieve-fern-adapter.yaml
+++ b/.github/workflows/update-trieve-fern-adapter.yaml
@@ -13,6 +13,7 @@ on:
       - 'clients/trieve-fern-adapter/src/**'
 jobs:
   version-and-publish:
+    if: ${{ !contains(github.event.head_commit.message, 'bump trieve-fern-adapter') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Currently, the trieve-fern-adapter workflow will create a PR to bump the package version. The merging of the bump version PR will result in the workflow to be triggered again. 

This PR will prevent the workflow to be triggered by merging the bump version PR. This completes the workflow.