### PR TITLE
chore: refactor search component UX for running local dev with public page

### DIFF
--- a/clients/search-component/README.md
+++ b/clients/search-component/README.md
@@ -143,7 +143,19 @@ MIT
 
 ## Development Guide
 
+
+### Deploying to view search playground UI
+
 The `example/` folder shows the example application for what rendering this would look like
+
+Run the example, search-component, css, javascript and watcher for demos page
+
+```sh
+$clients/search-component yarn all
+```
+
+
+or to run each individually
 
 Start the listener to update the search-component's css and javascript
 
@@ -158,4 +170,17 @@ Run the example application
 $clients/search-component cd example/
 $clients/search-component yarn
 $clients/search-component yarn dev
+```
+
+### Viewing it on demos page
+
+```sh
+cd clients/search-component/
+yarn all
+```
+
+Set environment variable in `server/.env`
+
+```sh
+SEARCH_COMPONENT_URL="http://localhost:8000"
 ```

--- a/clients/search-component/package.json
+++ b/clients/search-component/package.json
@@ -24,16 +24,19 @@
   "homepage": "https://github.com/devflowinc/trieve/tree/main/clients/search-component",
   "scripts": {
     "dev": "run-p watch:css watch:js",
-    "watch:css": "npx postcss src/app.css -o dist/index.css --watch",
-    "watch:js": "node ./scripts/watch.js",
-    "lint": "eslint",
-    "build:clean": "rm -rf dist && yarn type:dts && yarn build",
+    "all" : "run-p build:example watch:css watch:js serve",
+    "build:example": "cd example/ && yarn dev",
     "build": "run-s build:src build:css type:dts",
     "build:watch": "run-p watch:js build:src build:css type:dts",
     "build:src": "node ./scripts/build.js",
+    "watch:css": "npx postcss src/app.css -o dist/index.css --watch",
+    "watch:js": "node ./scripts/watch.js",
     "type:dts": "tsc --emitDeclarationOnly --declarationMap",
     "build:css": "npx postcss src/app.css -o dist/index.css && cp src/styles.d.ts dist/",
-    "prepublish": "yarn build:clean"
+    "build:clean": "rm -rf dist && yarn type:dts && yarn build",
+    "prepublish": "yarn build:clean",
+    "lint": "eslint",
+    "serve": "./serve-component"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",

--- a/clients/search-component/scripts/watch.js
+++ b/clients/search-component/scripts/watch.js
@@ -1,8 +1,7 @@
-const { context } = require("esbuild");
-const { options } = require("./build");
+const { context, build } = require("esbuild");
 
 const main = async () => {
-  let ctx1 = await context({
+  const ctx1 = await context({
     entryPoints: ["src/index.tsx"],
     treeShaking: true,
     outdir: "./dist",
@@ -14,6 +13,23 @@ const main = async () => {
     target: ["es2020"],
     external: ["react", "react-dom"],
   });
+  const vanillaJsBuild = await context({
+    entryPoints: ["src/vanilla/index.tsx"],
+    treeShaking: true,
+    outdir: "./dist/vanilla/",
+    sourcemap: false,
+    splitting: true,
+    bundle: true,
+    minify: true,
+    format: "esm",
+    target: ["es2020"],
+  });
+
+  Promise.all([
+    ctx1.watch(),
+    vanillaJsBuild.watch()
+  ])
+
 };
 
 main();


### PR DESCRIPTION
Main changes

### Deploying to view search playground UI

The `example/` folder shows the example application for what rendering this would look like

Run the example, search-component, css, javascript and watcher for demos page

```sh
$clients/search-component yarn all
```


or to run each individually

Start the listener to update the search-component's css and javascript

```sh
$clients/search-component yarn
$clients/search-component yarn dev
```

----------------------------

### Viewing it on demos page

```sh
cd clients/search-component/
yarn all
```

Set environment variable in `server/.env`

```sh
SEARCH_COMPONENT_URL="http://localhost:8000"
```