### PR TITLE
feat: add dataset ID support

### DIFF
--- a/clients/mcp-server/README.md
+++ b/clients/mcp-server/README.md
@@ -27,9 +27,12 @@ Required environment variables:
 - `TRIEVE_API_KEY`: Your Trieve API key from dashboard.trieve.ai
 - `TRIEVE_ORGANIZATION_ID`: Your Trieve organization ID from dashboard.trieve.ai
 
-Alternatively, you can provide these credentials via command-line arguments:
+Optional environment variables:
+- `TRIEVE_DATASET_ID`: Specific dataset ID to use (if not provided via CLI)
+
+Command-line arguments (override environment variables):
 ```bash
-mcp-server-trieve --api-key <your-api-key> --org-id <your-org-id>
+trieve-mcp-server --api-key <your-api-key> --org-id <your-org-id> [--dataset-id <dataset-id>]
 ```
 
 ## Usage
@@ -37,7 +40,7 @@ mcp-server-trieve --api-key <your-api-key> --org-id <your-org-id>
 ### Starting the Server
 
 ```bash
-mcp-server-trieve
+trieve-mcp-server
 ```
 
 ### Available Tools
@@ -48,12 +51,20 @@ Search through a specified Trieve dataset.
 Parameters:
 - `query` (string): The search query
 - `datasetId` (string): ID of the dataset to search in
+- `searchType` (string, optional): "semantic" (default), "fulltext", "hybrid", or "bm25"
+- `filters` (object, optional): Advanced filtering options
+- `highlightOptions` (object, optional): Customize result highlighting
+- `page` (number, optional): Page number, default 1
+- `pageSize` (number, optional): Results per page, default 10
 
 Example:
 ```json
 {
   "query": "example search query",
-  "datasetId": "your-dataset-id"
+  "datasetId": "your-dataset-id",
+  "searchType": "semantic",
+  "page": 1,
+  "pageSize": 10
 }
 ```
 
@@ -74,14 +85,15 @@ The Trieve MCP Server supports MCP integration with [Claude Desktop](https://mod
       "args": ["trieve-mcp-server@latest"],
       "env": {
         "TRIEVE_API_KEY": "$TRIEVE_API_KEY",
-        "TRIEVE_ORGANIZATION_ID": "$TRIEVE_ORGANIZATION_ID"
+        "TRIEVE_ORGANIZATION_ID": "$TRIEVE_ORGANIZATION_ID",
+        "TRIEVE_DATASET_ID": "$TRIEVE_DATASET_ID"
       }
     }
   }
 }
 ```
 
-Note, instead of environment variables, `--api-key` and `--org-id` can be used as arguments.
+Note: Instead of environment variables, `--api-key`, `--org-id`, and `--dataset-id` can be used as command-line arguments.
 
 Once Claude Desktop starts, attachments will be available that correspond to the [datasets available to the Trieve organization](https://docs.trieve.ai/guides/create-organizations-and-dataset). These can be used to select a dataset. After that, begin chatting with Claude and ask for information about the dataset. Claude will use search as needed in order to filter and break down queries, and may make multiple queries depending on your task.
 

--- a/clients/mcp-server/package.json
+++ b/clients/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trieve-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server providing agentic tools for the Trieve API using Model Context Protocol (MCP)",
   "private": false,
   "type": "module",


### PR DESCRIPTION
# Dataset ID Support for MCP Server

Fundamentally, the issue came down to I generated out a non-admin key for just one dataset, and didn't see any datasets, so this fixes that and handles the hierarchy. I imagine there's other rules and should get vitest going for this as well, but then someone additionally will need to make the MCP server testable (i.e. mock out the client and methods).

## Changes
- Added support for specifying a single dataset ID via CLI args (`--dataset-id`) or environment variables (`TRIEVE_DATASET_ID`)
- When dataset ID is provided, the MCP server will only expose and operate on that specific dataset
- Updated documentation to reflect new dataset ID options
- Bumped version to 0.1.3

## Testing
The changes have been tested with both CLI args and environment variables to ensure:
- Server properly initializes with dataset ID
- Search operations are scoped to the specified dataset
- Backwards compatibility is maintained when no dataset ID is provided

## Documentation
README.md has been updated with the new dataset ID configuration options.