### PR TITLE
feature: suggestions are scoped to group_tracking_id, bugfix: removeNode racecondition fixed

### DIFF
--- a/clients/search-component/package.json
+++ b/clients/search-component/package.json
@@ -19,7 +19,7 @@
       "import": "./dist/vanilla/index.js"
     }
   },
-  "version": "0.2.70",
+  "version": "0.2.71",
   "license": "MIT",
   "homepage": "https://github.com/devflowinc/trieve/tree/main/clients/search-component",
   "scripts": {

--- a/clients/search-component/package.json
+++ b/clients/search-component/package.json
@@ -19,7 +19,7 @@
       "import": "./dist/vanilla/index.js"
     }
   },
-  "version": "0.2.67",
+  "version": "0.2.70",
   "license": "MIT",
   "homepage": "https://github.com/devflowinc/trieve/tree/main/clients/search-component",
   "scripts": {

--- a/clients/search-component/src/TrieveModal/Chat/GroupChatImgCarousel.tsx
+++ b/clients/search-component/src/TrieveModal/Chat/GroupChatImgCarousel.tsx
@@ -11,12 +11,19 @@ export const GroupChatImgCarousel = () => {
     string[] | null
   >();
 
+  const [link, setLink] = useState<string>("");
+
   useEffect(() => {
     const setGroupCarousel = async () => {
       if (currentGroup) {
         const groupChunks = await cached(() => {
           return getAllChunksForGroup(currentGroup.id, trieveSDK);
         }, `chunk-ids-${currentGroup.id}`);
+
+        const firstLink = groupChunks.find(chunk => chunk.link)?.link || null;
+        if (firstLink) {
+          setLink(firstLink);
+        }
 
         const images = groupChunks
           .map((chunk) => {
@@ -39,9 +46,9 @@ export const GroupChatImgCarousel = () => {
       {currentGroup && groupCarouselItems ? (
         <div className="group-chat-carousel">
           {groupCarouselItems.map((image) => (
-            <div key={image}>
+            <a href={link} key={image}>
               <img className="max-h-[270px]" src={image} />
-            </div>
+            </a>
           ))}
         </div>
       ) : undefined}

--- a/clients/search-component/src/utils/hooks/useFollowupQuestions.ts
+++ b/clients/search-component/src/utils/hooks/useFollowupQuestions.ts
@@ -4,7 +4,7 @@ import { getSuggestedQuestions } from "../trieve";
 import { useModalState } from "./modal-context";
 
 export const useFollowupQuestions = () => {
-  const { query, trieveSDK } = useModalState();
+  const { query, trieveSDK, currentGroup } = useModalState();
   const [isLoading, setIsLoading] = useState(false);
   const [suggestedQuestions, setSuggestedQuestions] = useState<
     SuggestedQueriesResponse["queries"]
@@ -15,6 +15,7 @@ export const useFollowupQuestions = () => {
     const queries = await getSuggestedQuestions({
       trieve: trieveSDK,
       query,
+      group: currentGroup
     });
     setSuggestedQuestions(queries.queries.splice(0, 3));
     setIsLoading(false);
@@ -32,7 +33,8 @@ export const useFollowupQuestions = () => {
       const queries = await getSuggestedQuestions({
         trieve: trieveSDK,
         abortController,
-        query,
+        group: currentGroup,
+        context: "You are an assistant searching through a docs website"
       });
       setSuggestedQuestions(queries.queries.splice(0, 3));
       setIsLoading(false);

--- a/clients/search-component/src/utils/trieve.ts
+++ b/clients/search-component/src/utils/trieve.ts
@@ -1,4 +1,5 @@
 import {
+	ChunkGroup,
 	ChunkMetadata,
 	ChunkMetadataStringTagSet,
 	CountChunkQueryResponseBody,
@@ -258,19 +259,39 @@ export const getSuggestedQueries = async ({
 export const getSuggestedQuestions = async ({
 	trieve,
 	abortController,
-	query
+	context,
+	query,
+	group
 }: {
 	trieve: TrieveSDK;
 	abortController?: AbortController;
+	context?: string;
 	query?: string;
+	group?: ChunkGroup | null;
 }) => {
+	let suggestedQueriesContext = "You are a user searching through a docs website"
+	if (context) {
+		suggestedQueriesContext = context
+	}
 	return trieve.suggestedQueries(
 		{
 			...(query && { query }),
 			suggestion_type: "question",
 			search_type: "semantic",
-			context: "You are a user searching through a docs website",
-			suggestions_to_create: 3
+			context: suggestedQueriesContext,
+			suggestions_to_create: 3,
+			...(group && group?.tracking_id && {
+				filters: {
+					must: [
+						{
+							field: "group_tracking_ids",
+							match_all: [
+								group.tracking_id
+							]
+						}
+					]
+				}
+			})
 		},
 		abortController?.signal
 	);


### PR DESCRIPTION
Fixed removeNode error hopefully, was happening due to a race condition, hard to see if it got fixed fully.

Also now add a filter to `suggestedQueries` for group_id so follow up questions are based on the context. Example of questions, they do look better.

![image](https://github.com/user-attachments/assets/6b34408b-185e-4792-9ff4-254519a50ba8)
