### PR TITLE
revert: autofill favicon public page icon from scrape settings

### DIFF
--- a/frontends/dashboard/src/hooks/usePublicPageSettings.tsx
+++ b/frontends/dashboard/src/hooks/usePublicPageSettings.tsx
@@ -79,23 +79,6 @@ export const { use: usePublicPage, provider: PublicPageProvider } =
       }
     });
 
-    // If the dataset has a url in crawl_options, automatically fill out a favicon.ico.
-    createEffect(() => {
-      if (
-        crawlSettingsQuery.data?.site_url &&
-        !extraParams.brandLogoImgSrcUrl
-      ) {
-        const stripTrailingSlash = (str: string) => {
-          return str.endsWith("/") ? str.slice(0, -1) : str;
-        };
-
-        setExtraParams(
-          "brandLogoImgSrcUrl",
-          stripTrailingSlash(crawlSettingsQuery.data.site_url) + "/favicon.ico",
-        );
-      }
-    });
-
     // manually set the array for rolemessages to simplify logic
     // context blocks until it's set
     createEffect(() => {


### PR DESCRIPTION
This reverts commit 2a37a7d1914965f0a0eff09a00c3c1321008275c.

## Please indicate what issue this PR is related to and @ any maintainers who are relevant
