### PR TITLE
feature: fine tune tracing on fetch from postgres

### DIFF
--- a/server/src/operators/search_operator.rs
+++ b/server/src/operators/search_operator.rs
@@ -3233,14 +3233,12 @@ pub async fn autocomplete_chunks_query(
 
     let mut result_chunks = retrieve_chunks_from_point_ids(
         search_chunk_query_results.clone(),
-        None,
+        Some(timer),
         &data.clone().into(),
         config.QDRANT_ONLY,
         pool.clone(),
     )
     .await?;
-
-    timer.add("fetching from postgres");
 
     let first_increase = *search_chunk_query_results
         .batch_lengths


### PR DESCRIPTION
If passed timer is not null we have traces for both the pg call, and the time spent highlighting. Should hopefully help to narrow down our search.

https://github.com/devflowinc/trieve/blob/382c69a84036738355793190914fb76dc109bad8/server/src/operators/search_operator.rs#L1477-L1483

https://github.com/devflowinc/trieve/blob/382c69a84036738355793190914fb76dc109bad8/server/src/operators/search_operator.rs#L1577-L1579
