### PR TITLE
cleanup: use fa-chevron arrows + remove arrows on mobile

### DIFF
--- a/clients/search-component/src/TrieveModal/Chat/Carousel.tsx
+++ b/clients/search-component/src/TrieveModal/Chat/Carousel.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
 } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { ArrowLeftIcon, ArrowRightIcon } from "../icons";
 
 export const Carousel = ({ children }: { children: React.ReactNode }) => {
   const [itemsPerPage, setItemsPerPage] = useState(1);
@@ -97,10 +98,10 @@ export const Carousel = ({ children }: { children: React.ReactNode }) => {
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -10 }}
             transition={{ duration: 0.2 }}
-            className="tv-absolute tv-top-[43%] tv-left-2 tv-text-gray-100 tv-bg-gray-900/65 tv-rounded-full tv-px-4 tv-py-3 tv-cursor-pointer tv-z-[999]"
+            className="carousel-arrow tv-absolute tv-top-[43%] tv-left-2 tv-text-gray-100 tv-bg-gray-900/65 tv-rounded-full tv-px-4 tv-py-3 tv-cursor-pointer tv-z-[999]"
             onClick={() => handleArrowClick("left")}
           >
-            {String.fromCharCode(8592)}
+            <ArrowLeftIcon className="tv-w-2 tv-h-4" />
           </motion.button>
         )}
       </AnimatePresence>
@@ -146,10 +147,10 @@ export const Carousel = ({ children }: { children: React.ReactNode }) => {
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: 10 }}
             transition={{ duration: 0.2 }}
-            className="tv-absolute tv-top-[43%] tv-right-2 tv-text-gray-100 tv-bg-gray-900/65 tv-rounded-full tv-px-4 tv-py-3 tv-cursor-pointer tv-z-[999]"
+            className="carousel-arrow tv-absolute tv-top-[43%] tv-right-2 tv-text-gray-100 tv-bg-gray-900/65 tv-rounded-full tv-px-4 tv-py-3 tv-cursor-pointer tv-z-[999]"
             onClick={() => handleArrowClick("right")}
           >
-            {String.fromCharCode(8594)}
+            <ArrowRightIcon className="tv-w-2 tv-h-4" />
           </motion.button>
         )}
       </AnimatePresence>

--- a/clients/search-component/src/TrieveModal/Chat/Carousel.tsx
+++ b/clients/search-component/src/TrieveModal/Chat/Carousel.tsx
@@ -117,7 +117,7 @@ export const Carousel = ({ children }: { children: React.ReactNode }) => {
             className={`carousel-item tv-flex-shrink-0 tv-list-none tv-rounded-lg tv-overflow-hidden tv-bg-white tv-shadow-sm tv-border-2`}
             key={index}
             style={{
-              width: `calc((100% / ${itemsPerPage}) - 1rem)`,
+              width: `min(calc((100% / ${itemsPerPage}) - 1rem), calc(90% - 1rem))`,
               transition: "border-color 0.2s ease",
             }}
             initial={{ opacity: 0, y: 20 }}

--- a/clients/search-component/src/TrieveModal/icons.tsx
+++ b/clients/search-component/src/TrieveModal/icons.tsx
@@ -169,3 +169,33 @@ export const DownloadIcon = () => (
     <line x1="12" x2="12" y1="15" y2="3" />
   </svg>
 );
+
+export const ArrowRightIcon = (props: SVGAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 320 512"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z" />
+  </svg>
+);
+
+export const ArrowLeftIcon = (props: SVGAttributes<SVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 320 512"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z" />
+  </svg>
+);

--- a/clients/search-component/src/TrieveModal/index.css
+++ b/clients/search-component/src/TrieveModal/index.css
@@ -412,6 +412,10 @@ body {
           }
         }
 
+        .carousel-arrow {
+          @apply tv-hidden md:tv-block;
+        }
+
         .carousel-item-hidden {
           visibility: hidden;
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cce18501-fbf8-4e29-9365-083f4f364bb9)
![image](https://github.com/user-attachments/assets/81266954-a980-4864-b095-6111ff26ab61)
