### PR TITLE
 bugfix: call highlight_chunks in a web::block, fix ineffecient comparision operation

### DIFF
--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -1719,6 +1719,7 @@ pub fn get_highlights_with_exact_match(
             .to_string(),
     );
     let query_split = cleaned_query.split_whitespace().collect_vec();
+    let num_words_in_query = query_split.len();
     let mut starting_length = 0;
     if !query_split.is_empty() {
         starting_length = query_split.len() - 1;
@@ -1761,6 +1762,12 @@ pub fn get_highlights_with_exact_match(
         .unique()
         .collect_vec();
     additional_multi_token_queries.sort_by(|a, b| {
+        // Use More effecient algo for ranking
+        //
+        if num_words_in_query > 20 {
+            return b.trim().len().cmp(&a.trim().len());
+        }
+
         let a_len = a.split_whitespace().count();
         let b_len: usize = b.split_whitespace().count();
         match b_len.cmp(&a_len) {


### PR DESCRIPTION
We had an edge case that when `query` gets very large, the comparison operator we use when evaluating the optimal highlight window gets way too large. Most minimal fix without many side effects is to only use this sort operation when the `query` is <= 20 words.

Additionally this moves highlight functionality into its on `web::block` so that it operates on a non receiving thread.