### PR TITLE
bugfix: fix must_not and should filters on search playground

### DIFF
--- a/frontends/search/src/components/SearchForm.tsx
+++ b/frontends/search/src/components/SearchForm.tsx
@@ -298,6 +298,16 @@ const SearchForm = (props: {
     }
   };
 
+  createEffect(() => {
+    if (mustNotFilters().length > 0) {
+      setTempFilterType("must not");
+    } else if (shouldFilters().length > 0) {
+      setTempFilterType("should");
+    } else {
+      setTempFilterType("must");
+    }
+  });
+
   return (
     <>
       <div class="w-full">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bd783315-39db-45fc-96bd-a8eca14c7a92)
![image](https://github.com/user-attachments/assets/9fe64ff7-0288-4cb8-943e-79047f04fec3)

