### PR TITLE
Revert "feature: use broccoli fairness queue for ingestion"

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "broccoli_queue"
-version = "0.2.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89fc43266bd4a9385ffef4dd4392432d4f16bc13449266bac957b9465786f60"
+checksum = "270916c445aa80134c70b44449021d1169832418532812d4a27ff18c0eed60ee"
 dependencies = [
  "async-trait",
  "bb8-redis 0.18.0",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -834,13 +834,12 @@ dependencies = [
 
 [[package]]
 name = "broccoli_queue"
-version = "0.2.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270916c445aa80134c70b44449021d1169832418532812d4a27ff18c0eed60ee"
+checksum = "3be7581e0ad10a1479943d3e43c7dbd7adfcd597cfe8bf58c1a9212f7b148c50"
 dependencies = [
  "async-trait",
  "bb8-redis 0.18.0",
- "dashmap",
  "futures",
  "log",
  "redis 0.27.6",
@@ -1564,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -174,7 +174,7 @@ sanitize_html = "0.8.1"
 minijinja-embed = "2.2.0"
 minijinja = { version = "2.2.0", features = ["loader", "json"] }
 hallucination-detection = { version = "0.1.5", default-features = false, optional = true }
-broccoli_queue = { version = "0.2.1", features = ["redis"] }
+broccoli_queue = "0.1.2"
 youtube-transcript = { git = "https://github.com/densumesh/summarizer.git" }
 bytes = "1.9.0"
 pagefind = { version = "1.3.0" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -174,7 +174,7 @@ sanitize_html = "0.8.1"
 minijinja-embed = "2.2.0"
 minijinja = { version = "2.2.0", features = ["loader", "json"] }
 hallucination-detection = { version = "0.1.5", default-features = false, optional = true }
-broccoli_queue = { version = "0.2.3", features = ["redis"] }
+broccoli_queue = { version = "0.2.1", features = ["redis"] }
 youtube-transcript = { git = "https://github.com/densumesh/summarizer.git" }
 bytes = "1.9.0"
 pagefind = { version = "1.3.0" }

--- a/server/src/bin/etl-worker.rs
+++ b/server/src/bin/etl-worker.rs
@@ -238,7 +238,7 @@ async fn webhook_response(
         };
 
         broccoli_queue
-            .publish("update_chunk_queue", None, &message, None)
+            .publish("update_chunk_queue", &message, None)
             .await?;
     }
 

--- a/server/src/bin/ingestion-worker.rs
+++ b/server/src/bin/ingestion-worker.rs
@@ -229,6 +229,7 @@ async fn ingestion_worker(
     ingestion_message: BulkUploadIngestionMessage,
     web_pool: actix_web::web::Data<models::Pool>,
 ) -> Result<(), BroccoliError> {
+    log::info!("Starting ingestion service thread");
     log::info!("Selecting dataset for ingestion message");
     let dataset_result: Result<models::Dataset, ServiceError> =
         get_dataset_by_id_query(ingestion_message.dataset_id, web_pool.clone()).await;

--- a/server/src/handlers/etl_handler.rs
+++ b/server/src/handlers/etl_handler.rs
@@ -61,7 +61,7 @@ pub async fn create_etl_job(
     };
 
     broccoli_queue
-        .publish("etl_queue", None, &payload, None)
+        .publish("etl_queue", &payload, None)
         .await
         .map_err(|e| {
             log::error!("Error publishing to queue: {:?}", e);
@@ -82,7 +82,7 @@ pub async fn webhook_response(
     broccoli_queue: web::Data<BroccoliQueue>,
 ) -> Result<HttpResponse, actix_web::Error> {
     broccoli_queue
-        .publish("etl_queue", None, &data.clone(), None)
+        .publish("etl_queue", &data.clone(), None)
         .await
         .map_err(|e| {
             log::error!("Error publishing to queue: {:?}", e);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,8 +5,6 @@
 #[macro_use]
 extern crate diesel;
 
-use std::ops::Deref;
-
 use crate::{
     errors::{custom_json_error_handler, ServiceError},
     handlers::{auth_handler::build_oidc_client, metrics_handler::Metrics},
@@ -577,16 +575,6 @@ impl Modify for SecurityAddon {
 )]
 pub struct ApiDoc;
 
-pub struct FairBroccoliQueue(BroccoliQueue);
-
-impl Deref for FairBroccoliQueue {
-    type Target = BroccoliQueue;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 pub fn main() -> std::io::Result<()> {
     dotenvy::dotenv().ok();
 
@@ -740,10 +728,6 @@ pub fn main() -> std::io::Result<()> {
             std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to create broccoli queue {:?}", e))
         })?;
 
-        let fair_broccoli_queue = BroccoliQueue::builder(redis_url).pool_connections(redis_connections.try_into().unwrap()).enable_fairness(true).build().await.map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to create broccoli queue {:?}", e))
-        })?;
-
         let num_workers: usize = match std::env::var("NUM_WORKERS") {
             Ok(str_value) => {
                 str_value.parse().unwrap_or(4)
@@ -777,7 +761,6 @@ pub fn main() -> std::io::Result<()> {
                 .app_data(web::Data::new(metrics.clone()))
                 .app_data(detector.clone())
                 .app_data(web::Data::new(broccoli_queue.clone()))
-                .app_data(web::Data::new(FairBroccoliQueue(fair_broccoli_queue.clone())))
                 .wrap(from_fn(middleware::timeout_middleware::timeout_15secs))
                 .wrap(from_fn(middleware::metrics_middleware::error_logging_middleware))
                 .wrap(middleware::api_version::ApiVersionCheckFactory)

--- a/server/src/operators/crawl_operator.rs
+++ b/server/src/operators/crawl_operator.rs
@@ -347,7 +347,7 @@ pub async fn create_youtube_crawl_request(
         dataset_id,
     };
     broccoli_queue
-        .publish("video_queue", None, &message, None)
+        .publish("video_queue", &message, None)
         .await
         .map_err(|e| {
             log::error!("Error publishing message to video_queue: {:?}", e);


### PR DESCRIPTION
Reverts devflowinc/trieve#3273

We need to ensure any messages that add to the `ingestion` queue also use the brocolli queuing logic.