### PR TITLE
fix: only show rag output in chat playground

### DIFF
--- a/frontends/dashboard/src/analytics/components/SingleRagInfo/index.tsx
+++ b/frontends/dashboard/src/analytics/components/SingleRagInfo/index.tsx
@@ -57,6 +57,22 @@ export const SingleRAGQuery = (props: SingleRAGQueryProps) => {
         ?.find((d) => d.dataset.id === props.rag_data.dataset_id)?.dataset.name;
     });
 
+    const llm_output = createMemo(() => {
+      const response = props.rag_data.llm_response;
+      // chunks first
+      if (response.includes("}]||")) {
+        return (
+          props.rag_data.llm_response.split("}]||").slice(-1)[0] ??
+          props.rag_data.llm_response
+        );
+      } else if (response.includes("||[{")) {
+        return (
+          props.rag_data.llm_response.split("||[{")[0] ??
+          props.rag_data.llm_response
+        );
+      }
+    });
+
     return (
       <div class="flex flex-col gap-8">
         <div>
@@ -130,7 +146,7 @@ export const SingleRAGQuery = (props: SingleRAGQueryProps) => {
         <Show when={props.rag_data.llm_response}>
           <Card title="LLM Response">
             <ul>
-              <li>{props.rag_data.llm_response}</li>
+              <li>{llm_output()}</li>
             </ul>
           </Card>
         </Show>


### PR DESCRIPTION

BEFORE: 
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/b53089d6-bf8d-4e2f-8f9a-15188b01d682" />
AFTER: 
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/b7802a16-b457-4acc-b97b-27738c115c6e" />
