### PR TITLE
bugfix: use the correct default for the file upload route

### DIFF
--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -180,8 +180,22 @@ pub fn preprocess_file_to_chunks(
     html_content: String,
     upload_file_data: UploadFileReqPayload,
 ) -> Result<Vec<String>, ServiceError> {
-    let split_regex: Option<Regex> = upload_file_data
-        .split_delimiters
+    let split_delims = if let Some(split_delims) = upload_file_data.split_delimiters {
+        let filtered_delimeters: Vec<String> = split_delims
+            .into_iter()
+            .filter(|delim| !delim.is_empty())
+            .collect::<Vec<String>>();
+
+        if filtered_delimeters.is_empty() {
+            None
+        } else {
+            Some(filtered_delimeters)
+        }
+    } else {
+        None
+    };
+
+    let split_regex: Option<Regex> = split_delims
         .map(|delimiters| {
             build_chunking_regex(delimiters).map_err(|e| {
                 log::error!("Could not parse chunking delimiters {:?}", e);

--- a/server/src/operators/parse_operator.rs
+++ b/server/src/operators/parse_operator.rs
@@ -97,7 +97,8 @@ pub fn coarse_doc_chunker(
 
     let pattern = match split_pattern {
         Some(pattern) => pattern,
-        None => Regex::new(r"[.!?\n]+").expect("Invalid regex"),
+        None => build_chunking_regex(vec![".".to_string(), "?".to_string(), "\\n".to_string()])
+            .expect("regex is always correct"),
     };
 
     let mut splits = pattern


### PR DESCRIPTION
Convert the defaults `split_delimiters` to route through the same logical path