### PR TITLE
feature: new qdrant migration stratedgy 

### DIFF
--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -932,3 +932,53 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  backfill-qdrant-from-pg:
+    name: Push Backfill Qdrant script
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: blacksmith-8vcpu-ubuntu-2204
+            platform: linux/amd64
+            tag: latest
+          # - runner: blacksmith-8vcpu-ubuntu-2204
+          #   platform: linux/arm64
+          #   tag: latest-arm
+          #   suffix: -arm
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            trieve/backfill-qdrant
+          tags: |
+            type=raw,${{matrix.tag}}
+            type=sha,suffix=${{matrix.suffix}}
+
+      - name: Build and push Docker image
+        uses: useblacksmith/build-push-action@v1.0.0-beta
+        with:
+          platforms: ${{ matrix.platform }}
+          context: server/
+          file: ./server/Dockerfile.backfill-qdrant-from-pg
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -81,6 +81,10 @@ path = "src/bin/crawl-cron-job.rs"
 name = "pagefind-worker"
 path = "src/bin/pagefind-worker.rs"
 
+[[bin]]
+name = "backfill-qdrant-from-pg"
+path = "src/bin/backfill-qdrant-from-pg.rs"
+
 [dependencies]
 actix-identity = { version = "0.7.1" }
 actix-session = { version = "0.9.0", features = [

--- a/server/Dockerfile.backfill-qdrant-from-pg
+++ b/server/Dockerfile.backfill-qdrant-from-pg
@@ -1,0 +1,28 @@
+FROM rust:1.81-slim-bookworm AS chef
+# We only pay the installation cost once, 
+# it will be cached from the second build onwards
+RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev g++ curl
+RUN cargo install cargo-chef 
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json --bin "backfill-qdrant-from-pg"
+# Build application
+COPY . .
+RUN cargo build --release --features "runtime-env" --bin "backfill-qdrant-from-pg"
+
+FROM debian:bookworm-slim as runtime
+RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev ca-certificates 
+WORKDIR /app
+COPY ./migrations/ /app/migrations
+COPY --from=builder /app/target/release/backfill-qdrant-from-pg /app/backfill-qdrant-from-pg
+
+
+EXPOSE 8090
+ENTRYPOINT ["/app/backfill-qdrant-from-pg"]

--- a/server/src/bin/backfill-qdrant-from-pg.rs
+++ b/server/src/bin/backfill-qdrant-from-pg.rs
@@ -1,0 +1,305 @@
+use std::collections::{HashMap, HashSet};
+
+use broccoli_queue::queue::BroccoliQueue;
+use diesel::prelude::*;
+use diesel_async::pooled_connection::{AsyncDieselConnectionManager, ManagerConfig};
+use diesel_async::RunQueryDsl;
+use itertools::Itertools;
+use qdrant_client::qdrant::point_id::PointIdOptions;
+use qdrant_client::qdrant::{GetPoints, PointId};
+use trieve_server::data::models::{
+    ChunkMetadataTypes, Dataset, DatasetConfiguration, IngestSpecificChunkMetadata,
+};
+use trieve_server::handlers::chunk_handler::{
+    BulkUploadIngestionMessage, ChunkReqPayload, UploadIngestionMessage,
+};
+use trieve_server::operators::chunk_operator::{
+    create_chunk_metadata, get_chunk_metadatas_from_point_ids,
+};
+use trieve_server::operators::qdrant_operator::{
+    get_qdrant_collection_from_dataset_config, get_qdrant_connection,
+};
+use trieve_server::{errors::ServiceError, establish_connection, get_env};
+
+struct CollectionToPointids {
+    qdrant_collection_name: String,
+    point_ids: HashSet<String>,
+}
+
+#[allow(clippy::print_stdout)]
+#[tokio::main]
+async fn main() -> Result<(), ServiceError> {
+    println!("starting");
+    dotenvy::dotenv().ok();
+    let database_url = get_env!("DATABASE_URL", "DATABASE_URL is not set");
+
+    let mut config = ManagerConfig::default();
+    config.custom_setup = Box::new(establish_connection);
+
+    let mgr = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new_with_config(
+        database_url,
+        config,
+    );
+
+    let pool = diesel_async::pooled_connection::deadpool::Pool::builder(mgr)
+        .max_size(3)
+        .build()
+        .expect("Failed to create diesel_async pool");
+
+    let postgres_fetch_points_count: i64 = std::env::var("POSTGRES_FETCH_POINTS_COUNT")
+        .unwrap_or("100".to_string())
+        .parse::<i64>()
+        .unwrap_or(100);
+
+    let web_pool = actix_web::web::Data::new(pool.clone());
+
+    let redis_url = get_env!("REDIS_URL", "REDIS_URL should be set");
+
+    let broccoli_queue = BroccoliQueue::builder(redis_url)
+        .pool_connections(5.try_into().unwrap())
+        .build()
+        .await
+        .expect("Failed to build broccoli queue");
+
+    let mut offset = Some(uuid::Uuid::nil());
+
+    while let Some(cur_offset) = offset {
+        use trieve_server::data::schema::chunk_group_bookmarks::dsl as chunk_group_bookmarks_columns;
+        use trieve_server::data::schema::chunk_metadata::dsl as chunk_metadata_columns;
+        use trieve_server::data::schema::datasets::dsl as datasets_columns;
+
+        let mut conn = pool.get().await.map_err(|_| {
+            ServiceError::BadRequest("Could not get database connection".to_string())
+        })?;
+
+        println!("Fetching from postgres @ {}", cur_offset);
+
+        // Get postgres_fetch_points_count chunk_metadata
+        let qdrant_dataset_id_pairs = chunk_metadata_columns::chunk_metadata
+            .select((
+                chunk_metadata_columns::id,
+                chunk_metadata_columns::qdrant_point_id,
+                chunk_metadata_columns::dataset_id,
+            ))
+            .filter(chunk_metadata_columns::id.ge(cur_offset))
+            .order_by(chunk_metadata_columns::id)
+            .limit(postgres_fetch_points_count)
+            .load::<(uuid::Uuid, uuid::Uuid, uuid::Uuid)>(&mut conn)
+            .await
+            .expect("Failed to query chunks");
+
+        println!("Got {} ids", qdrant_dataset_id_pairs.len());
+
+        let chunk_ids = qdrant_dataset_id_pairs
+            .iter()
+            .map(|(chunk_id, _, _)| chunk_id)
+            .collect_vec();
+
+        offset = chunk_ids.iter().max().copied().copied();
+        if qdrant_dataset_id_pairs.len() < (postgres_fetch_points_count as usize) {
+            println!("setting offset to None");
+            offset = None;
+        }
+
+        let groups_ids_to_chunk_ids = chunk_group_bookmarks_columns::chunk_group_bookmarks
+            .select((
+                chunk_group_bookmarks_columns::group_id,
+                chunk_group_bookmarks_columns::chunk_metadata_id,
+            ))
+            .filter(chunk_group_bookmarks_columns::chunk_metadata_id.eq_any(chunk_ids))
+            .load::<(uuid::Uuid, uuid::Uuid)>(&mut conn)
+            .await
+            .expect("Failed to query chunk groups");
+        // for each find qdrant collection name via dataset id
+
+        let dataset_id_config_pair = datasets_columns::datasets
+            .filter(
+                datasets_columns::id.eq_any(
+                    &qdrant_dataset_id_pairs
+                        .iter()
+                        .map(|(_, _, dataset_id)| dataset_id)
+                        .unique()
+                        .collect_vec(),
+                ),
+            )
+            .load::<Dataset>(&mut conn)
+            .await
+            .expect("Failed to load dataset settings");
+
+        // Modified version that combines by collection name
+        let collected_qdrant_ids: Vec<CollectionToPointids> = qdrant_dataset_id_pairs
+            .into_iter()
+            .filter_map(|(_, qdrant_point_id, dataset_id)| {
+                dataset_id_config_pair
+                    .iter()
+                    .find(|dataset| dataset.id == dataset_id)
+                    .map(|dataset| {
+                        let dataset_config =
+                            DatasetConfiguration::from_json(dataset.server_configuration.clone());
+                        (
+                            get_qdrant_collection_from_dataset_config(&dataset_config),
+                            qdrant_point_id.to_string(),
+                        )
+                    })
+            })
+            .fold(
+                HashMap::new(),
+                |mut acc: HashMap<String, HashSet<String>>, (collection_name, point_id)| {
+                    acc.entry(collection_name).or_default().insert(point_id);
+                    acc
+                },
+            )
+            .into_iter()
+            .map(|(qdrant_collection_name, point_ids)| CollectionToPointids {
+                point_ids,
+                qdrant_collection_name,
+            })
+            .collect();
+
+        // For each chunk, see if it exists in qdrant. use this id to check against prod
+        for collection_pairs in collected_qdrant_ids {
+            let qdrant_client = get_qdrant_connection(None, None)
+                .await
+                .expect("Failed to get qdrant connection");
+
+            println!(
+                "Checking if {} ids exist in {} collection",
+                collection_pairs.point_ids.len(),
+                collection_pairs.qdrant_collection_name,
+            );
+
+            let qdrant_point_ids_response = qdrant_client
+                .get_points(GetPoints {
+                    collection_name: collection_pairs.qdrant_collection_name,
+                    ids: collection_pairs
+                        .point_ids
+                        .iter()
+                        .map(|point_uuid| PointId::from(point_uuid.as_str()))
+                        .collect(),
+                    with_payload: Some(false.into()),
+                    with_vectors: Some(false.into()),
+                    read_consistency: None,
+                    shard_key_selector: None,
+                    timeout: None,
+                })
+                .await;
+
+            match qdrant_point_ids_response {
+                Ok(resp) => {
+                    let qdrant_points_existing = resp
+                        .result
+                        .iter()
+                        .filter_map(|point| {
+                            point.id.as_ref().map(|point_id| {
+                                match point_id.point_id_options.clone() {
+                                    Some(PointIdOptions::Uuid(qdrant_uuid)) => qdrant_uuid,
+                                    _ => unreachable!(),
+                                }
+                            })
+                        })
+                        .collect::<HashSet<String>>();
+
+                    // Collect each missing point into list
+                    let missing_points: Vec<uuid::Uuid> = collection_pairs
+                        .point_ids
+                        .difference(&qdrant_points_existing)
+                        .filter_map(|string_id| uuid::Uuid::parse_str(string_id).ok())
+                        .collect_vec();
+
+                    // Reingest each set of missing points.
+
+                    println!("{} Points are missing, reingesting", missing_points.len());
+
+                    let chunk_metadatas =
+                        get_chunk_metadatas_from_point_ids(missing_points, web_pool.clone())
+                            .await?;
+
+                    let chunk_messages: Vec<BulkUploadIngestionMessage> = chunk_metadatas
+                        .iter()
+                        .filter_map(|chunk| {
+                            if let ChunkMetadataTypes::Metadata(chunk) = chunk {
+                                let group_ids: Vec<uuid::Uuid> = groups_ids_to_chunk_ids
+                                    .iter()
+                                    .filter(|(_, chunk_id)| *chunk_id == chunk.id)
+                                    .map(|(group_id, _)| group_id)
+                                    .cloned()
+                                    .collect();
+
+                                let upload_message = ChunkReqPayload {
+                                    chunk_html: chunk.chunk_html.clone(),
+                                    semantic_content: None,
+                                    link: chunk.link.clone(),
+                                    tag_set: chunk.tag_set.clone().map(|tag_set| {
+                                        tag_set.split(',').map(|tag| tag.to_string()).collect()
+                                    }),
+                                    num_value: chunk.num_value,
+                                    metadata: chunk.metadata.clone(),
+                                    tracking_id: chunk.tracking_id.clone(),
+                                    upsert_by_tracking_id: Some(false),
+                                    group_ids: Some(group_ids),
+                                    group_tracking_ids: None,
+                                    time_stamp: chunk
+                                        .time_stamp
+                                        .map(|timestamp| timestamp.clone().to_string()),
+                                    location: chunk.location,
+                                    image_urls: chunk.image_urls.clone().map(|image_urls| {
+                                        image_urls
+                                            .iter()
+                                            .filter_map(|image| image.clone())
+                                            .collect()
+                                    }),
+                                    weight: Some(chunk.weight),
+                                    split_avg: None,
+                                    convert_html_to_text: None,
+                                    fulltext_boost: None,
+                                    semantic_boost: None,
+                                    high_priority: None,
+                                };
+                                let (mut message, _) =
+                                    create_chunk_metadata(vec![upload_message], chunk.dataset_id)
+                                        .expect("timestamp is valid");
+
+                                let modified_messages = message
+                                    .ingestion_messages
+                                    .clone()
+                                    .into_iter()
+                                    .map(|message| UploadIngestionMessage {
+                                        ingest_specific_chunk_metadata:
+                                            IngestSpecificChunkMetadata {
+                                                id: chunk.id,
+                                                dataset_id: chunk.dataset_id,
+                                                qdrant_point_id: chunk.qdrant_point_id,
+                                            },
+                                        ..message
+                                    })
+                                    .collect();
+
+                                message.only_qdrant = Some(true);
+                                message.ingestion_messages = modified_messages;
+
+                                Some(message)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    for message in chunk_messages {
+                        broccoli_queue
+                            .publish(
+                                "sync_ingestion",
+                                Some(message.dataset_id.to_string()),
+                                &message,
+                                None,
+                            )
+                            .await
+                            .map_err(|err| ServiceError::BadRequest(err.to_string()))?;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/server/src/bin/crawl-worker.rs
+++ b/server/src/bin/crawl-worker.rs
@@ -908,12 +908,10 @@ async fn send_chunks(
 
     for chunk_segment in chunk_segments {
         let (ingestion_message, chunk_metadatas) =
-            create_chunk_metadata(chunk_segment, dataset_org_plan_sub.dataset.id)
-                .await
-                .map_err(|e| {
-                    log::error!("Could not create chunk metadata {:?}", e);
-                    ServiceError::InternalServerError("Could not create chunk metadata".to_string())
-                })?;
+            create_chunk_metadata(chunk_segment, dataset_org_plan_sub.dataset.id).map_err(|e| {
+                log::error!("Could not create chunk metadata {:?}", e);
+                ServiceError::InternalServerError("Could not create chunk metadata".to_string())
+            })?;
 
         if chunk_metadatas.is_empty() {
             continue;

--- a/server/src/bin/csv-jsonl-worker.rs
+++ b/server/src/bin/csv-jsonl-worker.rs
@@ -460,8 +460,7 @@ async fn process_csv_jsonl_file(
                             create_chunk_metadata(
                                 chunk_req_payloads.clone(),
                                 csv_jsonl_worker_message.dataset_id,
-                            )
-                            .await?;
+                            )?;
 
                         if !upsert_chunk_metadatas.is_empty() {
                             log::info!(
@@ -492,8 +491,7 @@ async fn process_csv_jsonl_file(
         let (upsert_chunk_ingestion_message, upsert_chunk_metadatas) = create_chunk_metadata(
             chunk_req_payloads.clone(),
             csv_jsonl_worker_message.dataset_id,
-        )
-        .await?;
+        )?;
 
         if !upsert_chunk_metadatas.is_empty() {
             log::info!(

--- a/server/src/bin/etl-worker.rs
+++ b/server/src/bin/etl-worker.rs
@@ -235,6 +235,7 @@ async fn webhook_response(
             convert_html_to_text: Some(true),
             fulltext_boost: fulltext_boost.clone(),
             semantic_boost: semantic_boost.clone(),
+            only_qdrant: Some(false),
         };
 
         broccoli_queue

--- a/server/src/bin/ingestion-worker.rs
+++ b/server/src/bin/ingestion-worker.rs
@@ -498,7 +498,7 @@ pub async fn bulk_upload_chunks(
 
     let qdrant_only = dataset_config.QDRANT_ONLY;
 
-    let inserted_chunk_metadatas = if qdrant_only {
+    let inserted_chunk_metadatas = if qdrant_only || payload.only_qdrant.unwrap_or(false) {
         ingestion_data.clone()
     } else {
         log::info!("Inserting {} chunks into database", ingestion_data.len());

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -1280,6 +1280,14 @@ impl ChunkMetadataTypes {
         }
     }
 
+    pub fn dataset_id(&self) -> Option<uuid::Uuid> {
+        match self {
+            ChunkMetadataTypes::Metadata(metadata) => Some(metadata.dataset_id),
+            ChunkMetadataTypes::ID(slim_metadata) => Some(slim_metadata.dataset_id),
+            ChunkMetadataTypes::Content(_) => None,
+        }
+    }
+
     pub fn qdrant_point_id(&self) -> uuid::Uuid {
         match self {
             ChunkMetadataTypes::Metadata(metadata) => metadata.qdrant_point_id,

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -217,6 +217,7 @@ pub struct UploadIngestionMessage {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BulkUploadIngestionMessage {
     pub attempt_number: usize,
+    pub only_qdrant: Option<bool>,
     pub dataset_id: uuid::Uuid,
     pub ingestion_messages: Vec<UploadIngestionMessage>,
 }
@@ -374,10 +375,10 @@ pub async fn create_chunk(
         chunks.partition(|chunk| chunk.upsert_by_tracking_id.unwrap_or(false));
 
     let (non_upsert_chunk_ingestion_message, non_upsert_chunk_metadatas) =
-        create_chunk_metadata(non_upsert_chunks, dataset_org_plan_sub.dataset.id).await?;
+        create_chunk_metadata(non_upsert_chunks, dataset_org_plan_sub.dataset.id)?;
 
     let (upsert_chunk_ingestion_message, upsert_chunk_metadatas) =
-        create_chunk_metadata(upsert_chunks, dataset_org_plan_sub.dataset.id).await?;
+        create_chunk_metadata(upsert_chunks, dataset_org_plan_sub.dataset.id)?;
 
     let chunk_metadatas = non_upsert_chunk_metadatas
         .clone()
@@ -418,6 +419,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: prio_chunks_message.clone(),
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -435,6 +437,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: non_prio_chunks_message,
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -452,6 +455,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: non_prio_chunks_message,
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -486,6 +490,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: prio_chunks_message.clone(),
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -503,6 +508,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: non_prio_chunks_message,
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -520,6 +526,7 @@ pub async fn create_chunk(
                         attempt_number: 0,
                         dataset_id: dataset_org_plan_sub.dataset.id,
                         ingestion_messages: non_prio_chunks_message,
+                        only_qdrant: None,
                     },
                     None,
                 )
@@ -756,6 +763,7 @@ pub struct UpdateIngestionMessage {
     pub convert_html_to_text: Option<bool>,
     pub fulltext_boost: Option<FullTextBoost>,
     pub semantic_boost: Option<SemanticBoost>,
+    pub only_qdrant: Option<bool>,
 }
 
 /// Update Chunk
@@ -885,6 +893,7 @@ pub async fn update_chunk(
         convert_html_to_text: update_chunk_data.convert_html_to_text,
         fulltext_boost: update_chunk_data.fulltext_boost.clone(),
         semantic_boost: update_chunk_data.semantic_boost.clone(),
+        only_qdrant: Some(false),
     };
 
     broccoli_queue
@@ -1024,6 +1033,7 @@ pub async fn update_chunk_by_tracking_id(
         convert_html_to_text: update_chunk_data.convert_html_to_text,
         fulltext_boost: None,
         semantic_boost: None,
+        only_qdrant: Some(false),
     };
 
     broccoli_queue

--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -2455,7 +2455,7 @@ pub async fn get_row_count_for_organization_id_query(
     Ok(chunk_metadata_count as usize)
 }
 
-pub async fn create_chunk_metadata(
+pub fn create_chunk_metadata(
     chunks: Vec<ChunkReqPayload>,
     dataset_uuid: uuid::Uuid,
 ) -> Result<(BulkUploadIngestionMessage, Vec<ChunkMetadata>), ServiceError> {
@@ -2526,6 +2526,7 @@ pub async fn create_chunk_metadata(
             attempt_number: 0,
             dataset_id: dataset_uuid,
             ingestion_messages,
+            only_qdrant: None,
         },
         chunk_metadatas,
     ))

--- a/server/src/operators/crawl_operator.rs
+++ b/server/src/operators/crawl_operator.rs
@@ -864,7 +864,7 @@ pub async fn process_crawl_doc(
     let chunks_to_upload = chunks.chunks(120);
     for batch in chunks_to_upload {
         let (chunk_ingestion_message, chunk_metadatas) =
-            create_chunk_metadata(batch.to_vec(), dataset_id).await?;
+            create_chunk_metadata(batch.to_vec(), dataset_id)?;
 
         if !chunk_metadatas.is_empty() {
             broccoli_queue

--- a/server/src/operators/file_operator.rs
+++ b/server/src/operators/file_operator.rs
@@ -399,12 +399,10 @@ pub async fn create_file_chunks(
     log::info!("Queuing chunks for creation");
     for chunk_segment in chunk_segments {
         let (ingestion_message, chunk_metadatas) =
-            create_chunk_metadata(chunk_segment, dataset_org_plan_sub.dataset.id)
-                .await
-                .map_err(|e| {
-                    log::error!("Could not create chunk metadata {:?}", e);
-                    ServiceError::BadRequest("Could not create chunk metadata".to_string())
-                })?;
+            create_chunk_metadata(chunk_segment, dataset_org_plan_sub.dataset.id).map_err(|e| {
+                log::error!("Could not create chunk metadata {:?}", e);
+                ServiceError::BadRequest("Could not create chunk metadata".to_string())
+            })?;
 
         if chunk_metadatas.is_empty() {
             continue;

--- a/server/src/operators/webhook_operator.rs
+++ b/server/src/operators/webhook_operator.rs
@@ -48,7 +48,7 @@ pub async fn publish_content<T: Into<ChunkReqPayload>>(
 ) -> Result<(), ServiceError> {
     let chunk: ChunkReqPayload = value.into();
 
-    let (upsert_message, _) = create_chunk_metadata(vec![chunk.clone()], dataset_id).await?;
+    let (upsert_message, _) = create_chunk_metadata(vec![chunk.clone()], dataset_id)?;
 
     broccoli_queue
         .publish(


### PR DESCRIPTION
Testing:

- ingest some data
- delete a qdrant collection
- run `cargo run --bin two-sync`
- run ingestion workers

Qdrant collection should be fully ingested