### PR TITLE
feature(shopify): split variant name by spaces

### DIFF
--- a/clients/trieve-shopify-extension/app/processors/getProducts.ts
+++ b/clients/trieve-shopify-extension/app/processors/getProducts.ts
@@ -66,6 +66,7 @@ function createChunkFromProduct(
   const semanticBoostPhrase = groupVariants ? variantTitle : productTitle;
   const fulltextBoostPhrase = groupVariants ? variantTitle : productTitle;
   const tags = product.tags;
+
   if (crawlOptions.include_metafields) {
     product.variants.nodes.forEach((v) => {
       let values: string[] = JSON.parse(
@@ -76,6 +77,7 @@ function createChunkFromProduct(
       tags.push(...values);
     });
   }
+  tags.push(...variantTitle.split(" / "));
   const metadata = {
     body_html: product.bodyHtml,
     variantName: variantTitle,
@@ -102,7 +104,7 @@ function createChunkFromProduct(
   return {
     chunk_html: chunkHtml,
     link,
-    tag_set: product.tags,
+    tag_set: tags,
     num_value: parseFloat(variant.price),
     metadata,
     tracking_id: groupVariants


### PR DESCRIPTION
Split `variantTitle` by " / " in order to extract all the variant titles. Should help for more accurate filtering.