### PR TITLE
feature(server): add `use_cursor` option for scroll through dataset groups on `/api/dataset/groups`

### DIFF
--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -3969,11 +3969,33 @@
           {
             "name": "page",
             "in": "path",
-            "description": "The page of groups to fetch. Page is 1-indexed.",
+            "description": "The page of groups to fetch. Page is 1-indexed. Not used if `use_cursor` = `false`.",
             "required": true,
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "use_cursor",
+            "in": "query",
+            "description": "Flag to enable `cursor` mode, this runs faster for large scroll operations. Defaults to false",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "The cursor offset for .Requires `use_cursor` = True. Defaults to `00000000-00000000-00000000-00000000`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
             }
           }
         ],
@@ -11960,11 +11982,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ChunkGroupAndFileId"
-            }
+            },
+            "description": "The list of all the groups."
+          },
+          "next_cursor": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Parameter for the next cursor offset.",
+            "nullable": true
           },
           "total_pages": {
             "type": "integer",
             "format": "int32",
+            "description": "Total number of pages. Pages is groups_count / 10",
             "minimum": 0
           }
         }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -945,23 +945,16 @@ pub fn main() -> std::io::Result<()> {
                                         ),
                                 )
                                 .service(
-                                    web::resource("/groups/{dataset_id}/{page}").route(web::get().to(
-                                        handlers::group_handler::get_groups_for_dataset,
-                                    )),
+                                    web::scope("/groups/{dataset_id}")
+                                        .route("", web::get().to( handlers::group_handler::get_groups_for_dataset,))
+                                        .route("/", web::get().to( handlers::group_handler::get_groups_for_dataset,))
+                                        .route("/{page}", web::get().to( handlers::group_handler::get_groups_for_dataset,))
                                 )
-                                .service(web::resource("/files/{dataset_id}/{page}").route(
-                                    web::get().to(handlers::file_handler::get_dataset_files_handler),
-                                )),
+                                .route("/files/{dataset_id}/{page}", web::get().to(handlers::file_handler::get_dataset_files_handler)),
                         )
                         .service(web::scope("/etl")
-                            .service(
-                                web::resource("/create_job")
-                                    .route(web::post().to(handlers::etl_handler::create_etl_job)),
-                            )
-                            .service(
-                                web::resource("/webhook")
-                                    .route(web::post().to(handlers::etl_handler::webhook_response)),
-                            )
+                            .route("/create_job", web::post().to(handlers::etl_handler::create_etl_job))
+                            .route("/webhook", web::post().to(handlers::etl_handler::webhook_response))
                         )
                         .service(
                             web::scope("/auth")


### PR DESCRIPTION
## Scrolling Dataset groups with a `cursor` object

Added request param flag for `use_cursor`. If set to `true`. `/api/dataset/groups` will return with a `next_cursor` parameter.
This should be passed into the next request as `cursor`.

See examples below

Request:
```
httpget $"https://api.trieve.ai/api/dataset/groups/($dataset_id)?use_cursor=true"
```

Response:
```
{
  "groups": [
    {
      "id": "00308933-2044-4e6a-b2a3-79f22d0293ac",
      "dataset_id": "82d6a576-1c98-4186-a3f2-25300452cf5c",
      "name": "8872437383420",
      "description": "",
      "tracking_id": "8872437383420",
      "tag_set": [],
      "metadata": {},
      "file_id": null,
      "created_at": "2025-02-14T23:51:06.641160",
      "updated_at": "2025-02-14T23:51:06.641160"
    },
   ...
  ],
  "total_pages": 18,
  "next_cursor": "120a60f7-5f23-4a14-ba7f-80136ecc1ec4"
}
```

`next_cursor` is: `120a60f7-5f23-4a14-ba7f-80136ecc1ec4`

Adding `cursor=120a60f7-5f23-4a14-ba7f-80136ecc1ec4` to the query body will start from that id. Defaults to uuid::nil() (all 0's)

```
httpget $"https://api.trieve.ai/api/dataset/groups/($dataset_id)?cursor=120a60f7-5f23-4a14-ba7f-80136ecc1ec4&use_cursor=true"
```

`next_cursor` will be `null` when there are no more groups left.

```
{
  "groups": [
    {
      "id": "120a60f7-5f23-4a14-ba7f-80136ecc1ec4",
      "dataset_id": "82d6a576-1c98-4186-a3f2-25300452cf5c",
      "name": "8739724394748",
      "description": "",
      "tracking_id": "8739724394748",
      "tag_set": [],
      "metadata": {},
      "file_id": null,
      "created_at": "2025-02-14T23:51:19.585796",
      "updated_at": "2025-02-14T23:51:19.585796"
    },
  ...
  ],
  "total_pages": 18,
  "next_cursor": "27f502a6-6a9e-47c6-ab77-8aaddf0c62be"
}
```

