### PR TITLE
refactor: added 1.2s debounce to Search when AIMon reranker is selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ cat .env.chat .env.search .env.server .env.docker-compose > .env
 ./convenience.sh -l
 ```
 
+### Install front-end packages for local dev
+
+```
+cd frontends
+yarn
+```
+`cd ..`
+
+```
+cd clients/ts-sdk
+yarn build
+```
+`cd ../..`
+
 ### Start services for local dev
 
 It is recommend to manage services through [tmuxp, see the guide here](https://gist.github.com/skeptrunedev/101c7a13bb9b9242999830655470efac) or terminal tabs.
@@ -172,14 +186,6 @@ cd frontends
 yarn
 yarn dev
 ```
-close and `cd ..`
-
-```
-cd clients/ts-sdk
-yarn build
-```
-close and `cd ../..`
-
 
 ```
 cd server


### PR DESCRIPTION
1. Implemented a 1.2-second debounce on the Search input to optimize performance when the AIMon reranker is selected, reducing redundant query executions during rapid user input.

2. Updated the README.md, to build the front-end before configuring services via `tmux`
According to my testing, `frontends` and `ts-sdk` need to be built before they can be set via `tmux`