### PR TITLE
feat(server): increase file_storage for free plans to also be in kb

### DIFF
--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -3895,7 +3895,7 @@ impl Default for StripePlan {
             id: uuid::Uuid::default(),
             stripe_id: "".to_string(),
             chunk_count: 1000,
-            file_storage: 1024,
+            file_storage: 1024 * 1024,
             user_count: 5,
             dataset_count: 10,
             message_count: 1000,


### PR DESCRIPTION
Recently we adjusted plans to be in kb. The only thing that wasn't updated was the hard coded file-storage parameter here