### PR TITLE
feature: filter by event_name instead of event_type. bugfix for displaying the item clicked

### DIFF
--- a/clients/search-component/package.json
+++ b/clients/search-component/package.json
@@ -19,7 +19,7 @@
       "import": "./dist/vanilla/index.js"
     }
   },
-  "version": "0.4.54",
+  "version": "0.4.55",
   "license": "MIT",
   "homepage": "https://github.com/devflowinc/trieve/tree/main/clients/search-component",
   "scripts": {

--- a/clients/search-component/src/TrieveModal/Chat/ResponseMessage.tsx
+++ b/clients/search-component/src/TrieveModal/Chat/ResponseMessage.tsx
@@ -154,7 +154,8 @@ export const Message = ({
 
       const clicked =
         productsWithClicks?.find(
-          (product) => product.chunk_id === item.chunk.id,
+          (product) =>
+            product.chunk_id === item.chunk.id && product.position == index - 1,
         ) != undefined;
       return (
         <a

--- a/clients/search-component/src/utils/hooks/chat-context.tsx
+++ b/clients/search-component/src/utils/hooks/chat-context.tsx
@@ -16,7 +16,7 @@ import { defaultHighlightOptions } from "../highlight";
 
 export type ChunkIdWithIndex = {
   chunk_id: string;
-  index: number;
+  position: number;
 };
 
 const scrollToBottomOfChatModalWrapper = () => {

--- a/clients/trieve-shopify-extension/app/components/analytics/chat/ChatEventsFilter.tsx
+++ b/clients/trieve-shopify-extension/app/components/analytics/chat/ChatEventsFilter.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@shopify/polaris";
-import { TopicEventFilter, EventTypesFilter } from "trieve-ts-sdk";
+import { TopicEventFilter, EventNamesFilter } from "trieve-ts-sdk";
 import { Dispatch, SetStateAction } from "react";
 
 interface EventFiltersProps {
@@ -7,10 +7,11 @@ interface EventFiltersProps {
   setEventsFilter: Dispatch<SetStateAction<TopicEventFilter>>;
 }
 
-const AVAILABLE_EVENT_TYPES: { label: string; value: EventTypesFilter }[] = [
-  { label: "Checkout", value: "purchase" },
-  { label: "Add to Cart", value: "add_to_cart" },
-  { label: "Click", value: "click" },
+const AVAILABLE_EVENT_TYPES: { label: string; value: EventNamesFilter }[] = [
+  { label: "Followup Clicked", value: "site-followup_query" },
+  { label: "Click", value: "Click" },
+  { label: "Add to Cart", value: "site-add_to_cart" },
+  { label: "Checkout", value: "site-checkout" },
 ];
 
 const eventTypeSelectOptions = [
@@ -38,7 +39,7 @@ export function EventFilters({
   const handleEventTypeChange = (selectedValue: string) => {
     setEventsFilter((prev: TopicEventFilter) => ({
       ...prev,
-      event_types: selectedValue ? [selectedValue as any] : [],
+      event_names: selectedValue ? [selectedValue as any] : [],
     }));
   };
 
@@ -46,7 +47,7 @@ export function EventFilters({
     ? "excludes"
     : "includes";
 
-  const selectedEventTypeValue = eventsFilters.event_types?.[0] || "";
+  const selectedEventTypeValue = eventsFilters.event_names?.[0] || "";
 
   return (
     <div className="flex items-center gap-2">

--- a/clients/trieve-shopify-extension/app/queries/analytics/chat.ts
+++ b/clients/trieve-shopify-extension/app/queries/analytics/chat.ts
@@ -99,7 +99,7 @@ export const allChatsQuery = (
         type: "topic_queries",
         page: page,
         topic_events_filter:
-          topic_event_filter.event_types.length > 0
+          topic_event_filter.event_names.length > 0
             ? topic_event_filter
             : undefined,
         sort_by,
@@ -107,7 +107,6 @@ export const allChatsQuery = (
       })) as TopicQueriesResponse;
       return {
         topics: result.topics,
-        events: result.events,
       } satisfies TopicQueriesResponse;
     },
   } satisfies QueryOptions;

--- a/clients/trieve-shopify-extension/app/routes/app._dashboard.chats.tsx
+++ b/clients/trieve-shopify-extension/app/routes/app._dashboard.chats.tsx
@@ -32,7 +32,7 @@ export default function ChatsPage() {
   const [query, setQuery] = useState("");
   const [filters, setFilters] = useState<TopicAnalyticsFilter>({});
   const [eventsFilters, setEventsFilter] = useState<TopicEventFilter>({
-    event_types: [], // if empty, whole filter undefined on crash
+    event_names: [], // if empty, whole filter undefined on crash
     inverted: false,
   });
   const [appliedFilters, setAppliedFilters] = useState<
@@ -69,6 +69,7 @@ export default function ChatsPage() {
       return previousData;
     }
 
+    console.log("getting data", data)
     if (!data?.topics) {
       return [];
     }
@@ -76,19 +77,10 @@ export default function ChatsPage() {
     // TODO: Create badge with "highest ranking event"
     let newData: AdvancedTableCell[][] =
       data?.topics.map((topic) => {
-        const topic_events = data?.events?.filter(
-          (event) => event.event_type === topic.topic_id
-        );
-
         return [
           { content: topic.name, url: `/app/chatview/${topic.topic_id}` },
           { content: topic.status },
           { content: topic.message_count.toLocaleString() },
-          {
-            content: topic.products_shown?.toLocaleString("en-US", {
-              maximumFractionDigits: 0,
-            }),
-          },
           {
             content: topic.avg_top_score?.toLocaleString("en-US", {
               maximumFractionDigits: 2,
@@ -444,6 +436,8 @@ export default function ChatsPage() {
     }
   }, [query]);
 
+  console.log("I am here data", mappedData);
+
   return (
     <AdvancedTableComponent
       additionalControls={
@@ -470,10 +464,6 @@ export default function ChatsPage() {
         {
           heading: "Message Count",
           tooltip: "The number of messages in the chat session.",
-        },
-        {
-          heading: "Products Shown",
-          tooltip: "The number of products displayed in the chat session.",
         },
         {
           heading: "Average Score",

--- a/clients/trieve-shopify-extension/app/routes/app._dashboard.chatview.$topic.tsx
+++ b/clients/trieve-shopify-extension/app/routes/app._dashboard.chatview.$topic.tsx
@@ -50,7 +50,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
 export default function ChatRoute() {
   const { topicId, messages, topicEvents } = useLoaderData<typeof loader>();
-  const { dataset, trieveKey } = useTrieve();
+  const { trieve, dataset, trieveKey } = useTrieve();
 
   const getEventLog = () => {
     const events: SidebarEvent[] = [];
@@ -125,6 +125,7 @@ export default function ChatRoute() {
             <Suspense fallback={null}>
               {typeof window !== "undefined" && (
                 <TrieveModalSearch
+                  baseUrl={trieve.trieve.baseUrl}
                   type="ecommerce"
                   defaultSearchMode="chat"
                   allowSwitchingModes={false}

--- a/clients/trieve-shopify-extension/package.json
+++ b/clients/trieve-shopify-extension/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.1.0",
     "tailwindcss": "^3.4.17",
-    "trieve-ts-sdk": "0.0.78",
+    "trieve-ts-sdk": "0.0.80",
     "vite-tsconfig-paths": "^5.0.1",
     "trieve-search-component": "0.4.54"
   },

--- a/clients/trieve-shopify-extension/package.json
+++ b/clients/trieve-shopify-extension/package.json
@@ -54,7 +54,7 @@
     "tailwindcss": "^3.4.17",
     "trieve-ts-sdk": "0.0.80",
     "vite-tsconfig-paths": "^5.0.1",
-    "trieve-search-component": "0.4.54"
+    "trieve-search-component": "0.4.55"
   },
   "devDependencies": {
     "@remix-run/eslint-config": "^2.7.1",

--- a/clients/trieve-shopify-extension/yarn.lock
+++ b/clients/trieve-shopify-extension/yarn.lock
@@ -9342,10 +9342,10 @@ trieve-ts-sdk@0.0.73:
   resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.73.tgz#9de17428ddb4b1f6d68709695f371d185c4bda79"
   integrity sha512-68iG/OlmKSGmnmI/J33S6VKleEAfq4txzARhvKv1g+CYSaG7HOH76n0cFDMtUUEEKn1PD4nV82uh5ZFtfIxD0A==
 
-trieve-ts-sdk@0.0.78:
-  version "0.0.78"
-  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.78.tgz#624ee877b829a84ffce633423876bb1d4ab49455"
-  integrity sha512-tYvJgZJzjTu4sXpdzf+BdcDtjKUxPlX6R0Paw7db0tO8SmE73BYmPoIm1zkMDCye76wyZuIdG/0rIMpR/TKfXA==
+trieve-ts-sdk@0.0.80:
+  version "0.0.80"
+  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.80.tgz#f42eb9cdc6f9f47acfc6f0e3f68a84dfd7bc0452"
+  integrity sha512-BzjOKAvRwvTvvc6q/SmFkPxm9XSJO/mzJ8G0RvZ/I2NoHKwqu7O3Kd2620sT+46FFvQi2/cOfOzHepd6qKfyvA==
 
 trim-lines@^3.0.0:
   version "3.0.1"

--- a/clients/trieve-shopify-extension/yarn.lock
+++ b/clients/trieve-shopify-extension/yarn.lock
@@ -9316,10 +9316,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-trieve-search-component@0.4.54:
-  version "0.4.54"
-  resolved "https://registry.yarnpkg.com/trieve-search-component/-/trieve-search-component-0.4.54.tgz#eadc7f8f1097a08760b128fd67ffefa9c730e0df"
-  integrity sha512-KB56sPi0O4NSYAl3/HncZi59SelwcYqGEebo3UqLhbYDTWxo1zNI3mllCj/eC/ZA8V835UzFTDTAHMPer4YDvw==
+trieve-search-component@0.4.55:
+  version "0.4.55"
+  resolved "https://registry.yarnpkg.com/trieve-search-component/-/trieve-search-component-0.4.55.tgz#7267b346412cbec129262e7c72848d3bf80b8a61"
+  integrity sha512-twYUpGIFoxiUWDOgVeOuMDOB+xlPr09AfCZZka7kmwccNtlTBMFZnmzs2RnyXirYmCeB/r0UgqEEIyYkpANkMg==
   dependencies:
     "@formkit/auto-animate" "^0.8.2"
     "@r2wc/react-to-web-component" "^2.0.3"

--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -9059,7 +9059,6 @@
           "message_count",
           "avg_top_score",
           "avg_hallucination_score",
-          "products_shown",
           "status"
         ],
         "properties": {
@@ -9093,11 +9092,6 @@
           },
           "owner_id": {
             "type": "string"
-          },
-          "products_shown": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
           },
           "status": {
             "type": "string"
@@ -11556,6 +11550,18 @@
             }
           }
         }
+      },
+      "EventNamesFilter": {
+        "type": "string",
+        "enum": [
+          "component_close",
+          "component_open",
+          "View",
+          "site-followup_query",
+          "Click",
+          "site-add_to_cart",
+          "site-checkout"
+        ]
       },
       "EventReturn": {
         "type": "object",
@@ -20295,14 +20301,14 @@
       "TopicEventFilter": {
         "type": "object",
         "required": [
-          "event_types",
+          "event_names",
           "inverted"
         ],
         "properties": {
-          "event_types": {
+          "event_names": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EventTypesFilter"
+              "$ref": "#/components/schemas/EventNamesFilter"
             },
             "description": "Filter by event type"
           },

--- a/clients/ts-sdk/package.json
+++ b/clients/ts-sdk/package.json
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "version": "0.0.79",
+  "version": "0.0.80",
   "license": "MIT",
   "scripts": {
     "lint": "eslint 'src/**/*.ts'",

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -561,7 +561,6 @@ export type ClickhouseTopicAnalyticsSummary = {
     message_count: number;
     name: string;
     owner_id: string;
-    products_shown: number;
     status: string;
     topic_id: string;
     updated_at: string;
@@ -1522,6 +1521,8 @@ export type EventNameAndCounts = {
 export type EventNameAndCountsResponse = {
     event_names: Array<EventNameAndCounts>;
 };
+
+export type EventNamesFilter = 'component_close' | 'component_open' | 'View' | 'site-followup_query' | 'Click' | 'site-add_to_cart' | 'site-checkout';
 
 export type EventReturn = {
     event_types: Array<(string)>;
@@ -4102,7 +4103,7 @@ export type TopicEventFilter = {
     /**
      * Filter by event type
      */
-    event_types: Array<EventTypesFilter>;
+    event_names: Array<EventNamesFilter>;
     inverted: boolean;
 };
 

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6438,7 +6438,7 @@ pub struct FloatRange {
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct TopicEventFilter {
     /// Filter by event type
-    pub event_types: Vec<EventTypesFilter>,
+    pub event_names: Vec<EventNamesFilter>,
     pub inverted: bool,
 }
 
@@ -7296,15 +7296,42 @@ pub enum EventTypesFilter {
     Purchase,
 }
 
-impl EventTypesFilter {
-    pub fn from_string(value: &str) -> EventTypesFilter {
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Display, PartialEq, PartialOrd)]
+pub enum EventNamesFilter {
+    #[display(rename = "component_close", fmt = "component_close")]
+    #[serde(rename = "component_close")]
+    ComponentClose,
+    #[display(rename = "component_open", fmt = "component_open")]
+    #[serde(rename = "component_open")]
+    ComponentOpen,
+    #[display(rename = "View", fmt = "View")]
+    #[serde(rename = "View")]
+    View,
+    #[display(rename = "site-followup_query", fmt = "site-followup_query")]
+    #[serde(rename = "site-followup_query")]
+    FollowupQuery,
+    #[display(rename = "Click", fmt = "Click")]
+    #[serde(rename = "Click")]
+    Click,
+    #[display(rename = "site-add_to_cart", fmt = "site-add_to_cart")]
+    #[serde(rename = "site-add_to_cart")]
+    AddToCart,
+    #[display(rename = "site-checkout", fmt = "site-checkout")]
+    #[serde(rename = "site-checkout")]
+    Checkout,
+}
+
+impl EventNamesFilter {
+    pub fn from_string(value: &str) -> EventNamesFilter {
         match value {
-            "view" => EventTypesFilter::View,
-            "filter_clicked" => EventTypesFilter::FilterClicked,
-            "click" => EventTypesFilter::Click,
-            "add_to_cart" => EventTypesFilter::AddToCart,
-            "purchase" => EventTypesFilter::Purchase,
-            _ => EventTypesFilter::View,
+            "component_close" => EventNamesFilter::ComponentClose,
+            "component_open" => EventNamesFilter::ComponentOpen,
+            "View" => EventNamesFilter::View,
+            "site-followup_query" => EventNamesFilter::FollowupQuery,
+            "Click" => EventNamesFilter::Click,
+            "site-add_to_cart" => EventNamesFilter::AddToCart,
+            "site-checkout" => EventNamesFilter::Checkout,
+            _ => EventNamesFilter::View,
         }
     }
 }
@@ -8071,7 +8098,6 @@ pub struct TopicAnalyticsSummaryClickhouse {
     pub avg_top_score: f64,
     pub avg_hallucination_score: f64,
     pub avg_query_rating: Option<f64>,
-    pub products_shown: u64,
     pub status: String,
 }
 
@@ -8087,7 +8113,6 @@ pub struct ClickhouseTopicAnalyticsSummary {
     pub avg_top_score: f64,
     pub avg_hallucination_score: f64,
     pub avg_query_rating: Option<f64>,
-    pub products_shown: u64,
     pub status: String,
 }
 
@@ -8104,7 +8129,6 @@ impl From<TopicAnalyticsSummaryClickhouse> for ClickhouseTopicAnalyticsSummary {
             avg_top_score: value.avg_top_score,
             avg_hallucination_score: value.avg_hallucination_score,
             avg_query_rating: value.avg_query_rating,
-            products_shown: value.products_shown,
             status: value.status,
         }
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -472,6 +472,7 @@ impl Modify for SecurityAddon {
             data::models::GetEventsRequestBody,
             data::models::GetEventsResponseBody,
             data::models::EventData,
+            data::models::EventNamesFilter,
             data::models::EventTypesFilter,
             data::models::RagTypes,
             data::models::RagQueryEvent,


### PR DESCRIPTION
- **feature: filter by `event_name`, instead of `event_type`. remove `prodct_view` join due to it removing data in the join**
- **bugfix: only display the product that was clicked if it was in the position matches**

## Please indicate what issue this PR is related to and @ any maintainers who are relevant
