### PR TITLE
bugfix: convert event_name string to the proper name for queries and refactored query to be a list of all events

### DIFF
--- a/clients/trieve-shopify-extension/app/components/analytics/AdvancedTableComponent.tsx
+++ b/clients/trieve-shopify-extension/app/components/analytics/AdvancedTableComponent.tsx
@@ -29,8 +29,10 @@ export interface Filter {
   pinned?: boolean;
 }
 
+// Either component or content is required
 export interface AdvancedTableCell {
-  content: string;
+  component?: React.ReactNode;
+  content?: string;
   url?: string;
 }
 
@@ -105,7 +107,7 @@ export const AdvancedTableComponent = ({
                 }))}
                 queryValue={query}
                 cancelAction={{
-                  onAction: () => {},
+                  onAction: () => { },
                   disabled: false,
                   loading: false,
                 }}
@@ -152,7 +154,7 @@ export const AdvancedTableComponent = ({
                         {heading.sortCol && (
                           <span className="ml-1">
                             {sortSelected[0].split(" ")[0] ===
-                            heading.sortCol ? (
+                              heading.sortCol ? (
                               sortSelected[0].split(" ")[1] === "asc" ? (
                                 <Icon source={ChevronUpIcon} tone="base" />
                               ) : (
@@ -188,25 +190,26 @@ export const AdvancedTableComponent = ({
                   id={index.toString()}
                   position={index}
                 >
-                  {row.map((cell, innerIndex) => (
-                    <IndexTable.Cell
-                      key={innerIndex}
-                      className="max-w-[200px] truncate"
-                    >
-                      {cell.url ? (
-                        <Link to={cell.url}>
-                          <InlineStack wrap={false}>
-                            <ViewIcon width={20} />
-                            <Text as="span" variant="bodyMd" truncate={true}>
-                              {cell.content}
-                            </Text>
-                          </InlineStack>
-                        </Link>
-                      ) : (
-                        cell.content
-                      )}
-                    </IndexTable.Cell>
-                  ))}
+                  {row.map((cell, innerIndex) => {
+                    const innerCell = cell.component ? cell.component : <Text as="span" variant="bodyMd" truncate={true}>{cell.content}</Text>;
+                    return (
+                      <IndexTable.Cell
+                        key={innerIndex}
+                        className="max-w-[250px] truncate"
+                      >
+                        {cell.url ? (
+                          <Link to={cell.url}>
+                            <InlineStack wrap={false}>
+                              <ViewIcon width={20} />
+                              {innerCell}
+                            </InlineStack>
+                          </Link>
+                        ) : (
+                          innerCell
+                        )}
+                      </IndexTable.Cell>
+                    );
+                  })}
                 </IndexTable.Row>
               );
             })}

--- a/clients/trieve-shopify-extension/app/components/analytics/chat/ChatEventsFilter.tsx
+++ b/clients/trieve-shopify-extension/app/components/analytics/chat/ChatEventsFilter.tsx
@@ -7,7 +7,7 @@ interface EventFiltersProps {
   setEventsFilter: Dispatch<SetStateAction<TopicEventFilter>>;
 }
 
-const AVAILABLE_EVENT_TYPES: { label: string; value: EventNamesFilter }[] = [
+export const AVAILABLE_EVENT_TYPES: { label: string; value: EventNamesFilter }[] = [
   { label: "Followup Clicked", value: "site-followup_query" },
   { label: "Click", value: "Click" },
   { label: "Add to Cart", value: "site-add_to_cart" },

--- a/clients/trieve-shopify-extension/package.json
+++ b/clients/trieve-shopify-extension/package.json
@@ -52,9 +52,9 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.1.0",
     "tailwindcss": "^3.4.17",
-    "trieve-search-component": "0.4.55",
-    "trieve-ts-sdk": "*",
-    "vite-tsconfig-paths": "^5.0.1"
+    "trieve-ts-sdk": "0.0.83",
+    "vite-tsconfig-paths": "^5.0.1",
+    "trieve-search-component": "0.4.55"
   },
   "devDependencies": {
     "@remix-run/eslint-config": "^2.7.1",

--- a/clients/trieve-shopify-extension/yarn.lock
+++ b/clients/trieve-shopify-extension/yarn.lock
@@ -9352,15 +9352,15 @@ trieve-search-component@0.4.55:
     tailwind-merge "^3.0.2"
     trieve-ts-sdk "0.0.73"
 
-trieve-ts-sdk@*:
-  version "0.0.83"
-  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.83.tgz#a9bd0bbd71e09f3f9017844d91894fde95c5edb9"
-  integrity sha512-EPDy342dDTNVmzzALMtk9JExCn5yt1oyp9moiS4VLyN52hFaKY4MxoSsEp9/Bp7PRNXS2Z8u1H+PTn+joovhbw==
-
 trieve-ts-sdk@0.0.73:
   version "0.0.73"
   resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.73.tgz#9de17428ddb4b1f6d68709695f371d185c4bda79"
   integrity sha512-68iG/OlmKSGmnmI/J33S6VKleEAfq4txzARhvKv1g+CYSaG7HOH76n0cFDMtUUEEKn1PD4nV82uh5ZFtfIxD0A==
+
+trieve-ts-sdk@0.0.83:
+  version "0.0.83"
+  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.83.tgz#a9bd0bbd71e09f3f9017844d91894fde95c5edb9"
+  integrity sha512-EPDy342dDTNVmzzALMtk9JExCn5yt1oyp9moiS4VLyN52hFaKY4MxoSsEp9/Bp7PRNXS2Z8u1H+PTn+joovhbw==
 
 trim-lines@^3.0.0:
   version "3.0.1"

--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -9093,7 +9093,7 @@
           "message_count",
           "avg_top_score",
           "avg_hallucination_score",
-          "status"
+          "event_names"
         ],
         "properties": {
           "avg_hallucination_score": {
@@ -9112,6 +9112,13 @@
           "created_at": {
             "type": "string"
           },
+          "event_names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "All event_names that are  associated with the topic, may contain duplicate names"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -9125,9 +9132,6 @@
             "type": "string"
           },
           "owner_id": {
-            "type": "string"
-          },
-          "status": {
             "type": "string"
           },
           "topic_id": {

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -557,11 +557,14 @@ export type ClickhouseTopicAnalyticsSummary = {
     avg_query_rating?: (number) | null;
     avg_top_score: number;
     created_at: string;
+    /**
+     * All event_names that are  associated with the topic, may contain duplicate names
+     */
+    event_names: Array<(string)>;
     id: string;
     message_count: number;
     name: string;
     owner_id: string;
-    status: string;
     topic_id: string;
     updated_at: string;
 };

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -8125,7 +8125,8 @@ pub struct TopicAnalyticsSummaryClickhouse {
     pub avg_top_score: f64,
     pub avg_hallucination_score: f64,
     pub avg_query_rating: Option<f64>,
-    pub status: String,
+    /// All event_names that are  associated with the topic, may contain duplicate names
+    pub event_names: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -8140,7 +8141,8 @@ pub struct ClickhouseTopicAnalyticsSummary {
     pub avg_top_score: f64,
     pub avg_hallucination_score: f64,
     pub avg_query_rating: Option<f64>,
-    pub status: String,
+    /// All event_names that are  associated with the topic, may contain duplicate names
+    pub event_names: Vec<String>,
 }
 
 impl From<TopicAnalyticsSummaryClickhouse> for ClickhouseTopicAnalyticsSummary {
@@ -8156,7 +8158,7 @@ impl From<TopicAnalyticsSummaryClickhouse> for ClickhouseTopicAnalyticsSummary {
             avg_top_score: value.avg_top_score,
             avg_hallucination_score: value.avg_hallucination_score,
             avg_query_rating: value.avg_query_rating,
-            status: value.status,
+            event_names: value.event_names,
         }
     }
 }

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -7349,6 +7349,18 @@ impl EventNamesFilter {
             _ => EventNamesFilter::View,
         }
     }
+
+    pub fn to_query_string(&self) -> String {
+        match self {
+            EventNamesFilter::ComponentClose => String::from("component_close"),
+            EventNamesFilter::ComponentOpen => String::from("component_open"),
+            EventNamesFilter::View => String::from("View"),
+            EventNamesFilter::FollowupQuery => String::from("site-followup_query"),
+            EventNamesFilter::Click => String::from("Click"),
+            EventNamesFilter::AddToCart => String::from("site-add_to_cart"),
+            EventNamesFilter::Checkout => String::from("site-checkout"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]

--- a/server/src/operators/analytics_operator.rs
+++ b/server/src/operators/analytics_operator.rs
@@ -1868,7 +1868,7 @@ pub async fn get_topic_queries_query(
         let event_match_string = topic_events_filter
             .event_names
             .iter()
-            .map(|event_name| format!("event_name = '{}'", event_name))
+            .map(|event_name| format!("event_name = '{}'", event_name.to_query_string()))
             .join(" OR ");
 
         if topic_events_filter.inverted {


### PR DESCRIPTION
- fixed a bug caused by the `event_name` enum not serializing to the proper string
- refactored query to be a list of all events that occurred.

![image](https://github.com/user-attachments/assets/1b73ef9f-36df-4d68-9209-f7445f63814f)
