### PR TITLE
feature: track monthly message usage for Shopify billing

### DIFF
--- a/clients/trieve-shopify-extension/app/queries/onboarding.ts
+++ b/clients/trieve-shopify-extension/app/queries/onboarding.ts
@@ -95,7 +95,6 @@ query GetStoreThemes {
 }
 `,
       );
-      console.log("THEME LIST", result);
       if (result.error) {
         console.error(result.error);
         throw result.error;

--- a/clients/trieve-shopify-extension/package.json
+++ b/clients/trieve-shopify-extension/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.1.0",
     "tailwindcss": "^3.4.17",
-    "trieve-ts-sdk": "0.0.80",
+    "trieve-ts-sdk": "0.0.81",
     "vite-tsconfig-paths": "^5.0.1",
     "trieve-search-component": "0.4.55"
   },

--- a/clients/trieve-shopify-extension/shopify.app.toml.dist
+++ b/clients/trieve-shopify-extension/shopify.app.toml.dist
@@ -29,6 +29,10 @@ api_version = "2025-01"
   topics = [ "products/delete" ]
   uri = "/webhooks/app/products/delete"
 
+  [[webhooks.subscriptions]]
+  topics = [ "app_subscriptions/update" ]
+  uri = "/webhooks/app/app_subscriptions/update"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products,read_products,read_themes"

--- a/clients/trieve-shopify-extension/yarn.lock
+++ b/clients/trieve-shopify-extension/yarn.lock
@@ -8964,8 +8964,16 @@ string-hash@^1.1.3:
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
   integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9073,7 +9081,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9342,10 +9357,10 @@ trieve-ts-sdk@0.0.73:
   resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.73.tgz#9de17428ddb4b1f6d68709695f371d185c4bda79"
   integrity sha512-68iG/OlmKSGmnmI/J33S6VKleEAfq4txzARhvKv1g+CYSaG7HOH76n0cFDMtUUEEKn1PD4nV82uh5ZFtfIxD0A==
 
-trieve-ts-sdk@0.0.80:
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.80.tgz#f42eb9cdc6f9f47acfc6f0e3f68a84dfd7bc0452"
-  integrity sha512-BzjOKAvRwvTvvc6q/SmFkPxm9XSJO/mzJ8G0RvZ/I2NoHKwqu7O3Kd2620sT+46FFvQi2/cOfOzHepd6qKfyvA==
+trieve-ts-sdk@0.0.81:
+  version "0.0.81"
+  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.81.tgz#85313acd01aff48798d5a37e0ba8a5d0bf6592e3"
+  integrity sha512-HLUH6xCeH3OTPGRN5cMnhV6NPAI46y/eJ386sIkq9HuuSQA2HwQi2NpA3Bp6wabo4QdlxwzVzzJLawec8aUwXQ==
 
 trim-lines@^3.0.0:
   version "3.0.1"
@@ -10005,8 +10020,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10019,6 +10033,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/server/ch_migrations/1744254191_create-rag-queries-monthly-counts/down.sql
+++ b/server/ch_migrations/1744254191_create-rag-queries-monthly-counts/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS mv_rag_queries_monthly_counts;

--- a/server/ch_migrations/1744254191_create-rag-queries-monthly-counts/up.sql
+++ b/server/ch_migrations/1744254191_create-rag-queries-monthly-counts/up.sql
@@ -1,0 +1,10 @@
+CREATE MATERIALIZED VIEW mv_rag_queries_monthly_counts
+ENGINE = SummingMergeTree()
+ORDER BY (dataset_id, month_year)
+POPULATE AS
+SELECT 
+    dataset_id,
+    formatDateTime(created_at, '%Y-%m') AS month_year,
+    COUNT(*) AS query_count
+FROM rag_queries
+GROUP BY dataset_id, month_year;

--- a/server/migrations/2025-04-10-010747_add-component-loads-limit-into-stripe-plans/down.sql
+++ b/server/migrations/2025-04-10-010747_add-component-loads-limit-into-stripe-plans/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE stripe_plans DROP COLUMN component_loads;
+

--- a/server/migrations/2025-04-10-010747_add-component-loads-limit-into-stripe-plans/up.sql
+++ b/server/migrations/2025-04-10-010747_add-component-loads-limit-into-stripe-plans/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE stripe_plans ADD COLUMN component_loads INTEGER NULL;

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -3837,6 +3837,7 @@ impl Invitation {
     "created_at": "2021-01-01 00:00:00.000",
     "updated_at": "2021-01-01 00:00:00.000",
     "name": "Free",
+    "component_loads": 1000,
 }))]
 #[diesel(table_name = stripe_plans)]
 pub struct StripePlan {
@@ -3852,6 +3853,7 @@ pub struct StripePlan {
     pub name: String,
     pub visible: bool,
     pub file_storage: i64,
+    pub component_loads: Option<i32>,
 }
 
 impl StripePlan {
@@ -3866,6 +3868,7 @@ impl StripePlan {
         amount: i64,
         name: String,
         visible: bool,
+        component_loads: Option<i32>,
     ) -> Self {
         StripePlan {
             id: uuid::Uuid::new_v4(),
@@ -3880,6 +3883,7 @@ impl StripePlan {
             updated_at: chrono::Utc::now().naive_local(),
             name,
             visible,
+            component_loads,
         }
     }
 }
@@ -3901,6 +3905,7 @@ impl Default for StripePlan {
                 updated_at: chrono::Utc::now().naive_local(),
                 name: "Unlimited".to_string(),
                 visible: true,
+                component_loads: Some(i32::MAX),
             };
         }
 
@@ -3917,6 +3922,7 @@ impl Default for StripePlan {
             updated_at: chrono::Utc::now().naive_local(),
             name: "Free".to_string(),
             visible: true,
+            component_loads: Some(1000),
         }
     }
 }

--- a/server/src/data/schema.rs
+++ b/server/src/data/schema.rs
@@ -242,6 +242,7 @@ diesel::table! {
         name -> Text,
         visible -> Bool,
         file_storage -> Int8,
+        component_loads -> Nullable<Int4>,
     }
 }
 

--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -273,6 +273,7 @@ pub async fn get_organization_usage(
                 ocr_pages_ingested: 0,
                 website_pages_scraped: 0,
                 events_ingested: 0,
+                current_months_message_count: 0,
             }
         }))
     } else {
@@ -312,6 +313,7 @@ pub struct ExtendedOrganizationUsageCount {
     // website pages scraped
     pub website_pages_scraped: u64,
     pub events_ingested: u64,
+    pub current_months_message_count: u64,
 }
 
 /// Get Organization Users

--- a/server/src/operators/dittofeed_operator.rs
+++ b/server/src/operators/dittofeed_operator.rs
@@ -312,9 +312,15 @@ pub async fn send_user_ditto_identity(
         .json(&batch_request)
         .send()
         .await
-        .map_err(|e| ServiceError::BadRequest(e.to_string()))?
+        .map_err(|e| {
+            log::error!("Error sending request to Dittofeed for /apps/batch: {}", e);
+            ServiceError::BadRequest(e.to_string())
+        })?
         .error_for_status()
-        .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
+        .map_err(|e| {
+            log::error!("Error sending request to Dittofeed /apps/batch: {}", e);
+            ServiceError::BadRequest(e.to_string())
+        })?;
 
     Ok(())
 }
@@ -339,9 +345,15 @@ pub async fn send_ditto_event(event: DittoTrackRequest) -> Result<(), ServiceErr
         .json(&event)
         .send()
         .await
-        .map_err(|e| ServiceError::BadRequest(e.to_string()))?
+        .map_err(|e| {
+            log::error!("Error sending request to Dittofeed for /apps/track: {}", e);
+            ServiceError::BadRequest(e.to_string())
+        })?
         .error_for_status()
-        .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
+        .map_err(|e| {
+            log::error!("Error sending request to Dittofeed for /apps/track: {}", e);
+            ServiceError::BadRequest(e.to_string())
+        })?;
 
     Ok(())
 }

--- a/server/src/operators/payment_operator.rs
+++ b/server/src/operators/payment_operator.rs
@@ -213,7 +213,6 @@ pub async fn create_stripe_plan_query(
 ) -> Result<StripePlan, ServiceError> {
     use crate::data::schema::stripe_plans::dsl as stripe_plans_columns;
 
-    // TODO: Make this configurable
     let stripe_plan = StripePlan::from_details(
         stripe_id,
         10000,
@@ -224,6 +223,7 @@ pub async fn create_stripe_plan_query(
         amount,
         "Project".to_string(),
         false,
+        Some(1000),
     );
 
     let mut conn = pool


### PR DESCRIPTION
- **feat(server): add component loads limit to stripe plans and update related models**
- **feat(server): add current month's message count to organization usage metrics and create related database view**

End result is that pulling organization usage is much faster (due to parallelization) and the monthly messages come out of the mv. 

Response sample: 

```json
{
    "search_tokens": 210,
    "message_tokens": 24612,
    "dataset_count": 1,
    "user_count": 1,
    "file_storage": 0,
    "message_count": 17,
    "search_count": 41,
    "chunk_count": 70,
    "bytes_ingested": 363208,
    "tokens_ingested": 8317,
    "ocr_pages_ingested": 0,
    "website_pages_scraped": 0,
    "events_ingested": 58,
    "current_months_message_count": 17
}
```