### PR TITLE
styling: empty state for dashboard homepage title

### DIFF
--- a/clients/trieve-shopify-extension/app/components/analytics/BasicTableComponent.tsx
+++ b/clients/trieve-shopify-extension/app/components/analytics/BasicTableComponent.tsx
@@ -49,15 +49,19 @@ export const BasicTableComponent = ({
         )}
       </div>
       <Box minHeight="14px">
-        <DataTable
-          truncate
-          hasZebraStripingOnData
-          sortable={sortableColumns}
-          onSort={onSort}
-          rows={data}
-          columnContentTypes={tableContentTypes}
-          headings={tableHeadings}
-        />
+        {data.length <= 0 ? (
+          <div className="w-full text-center pt-6 pb-4 opacity-70">No Data</div>
+        ) : (
+          <DataTable
+            truncate
+            hasZebraStripingOnData
+            sortable={sortableColumns}
+            onSort={onSort}
+            rows={data}
+            columnContentTypes={tableContentTypes}
+            headings={tableHeadings}
+          />
+        )}
         {!hidePagination && (
           <div className="flex justify-end mt-2">
             <Pagination


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
Adds an empty state for the main page tables. 
Makes things more polished especially for the user's first ever view of the dashboard. 

BEFORE: 
![image](https://github.com/user-attachments/assets/c3445f5b-98c7-452b-95e0-8f3edacbaef3)

AFTER:
![image](https://github.com/user-attachments/assets/b37bf996-1f19-484b-8097-7009fd14c16d)
