### PR TITLE
refactor: modify update all dataset configurations to match on existing types

### DIFF
--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -434,8 +434,10 @@ pub async fn remove_user_from_org(
     }
 }))]
 pub struct UpdateAllOrgDatasetConfigsReqPayload {
+    /// The configuration to provide a filter on what datasets to update.
+    pub from_configuration: Option<serde_json::Value>,
     /// The new configuration for all datasets in the organization. Only the specified keys in the configuration object will be changed per dataset such that you can preserve dataset unique values.
-    pub dataset_config: serde_json::Value,
+    pub to_configuration: serde_json::Value,
 }
 
 /// Update All Dataset Configurations
@@ -469,9 +471,12 @@ pub async fn update_all_org_dataset_configs(
         return Ok(HttpResponse::Forbidden().finish());
     };
 
-    let new_dataset_config = req_payload.dataset_config.clone();
+    let req_payload = req_payload.into_inner();
 
-    update_all_org_dataset_configs_query(organization_id, new_dataset_config, pool).await?;
+    let new_dataset_config = req_payload.to_configuration.clone();
+    let from_configuration = req_payload.from_configuration.clone();
+
+    update_all_org_dataset_configs_query(organization_id, new_dataset_config, from_configuration, pool).await?;
 
     Ok(HttpResponse::NoContent().finish())
 }

--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -435,7 +435,7 @@ pub async fn remove_user_from_org(
 }))]
 pub struct UpdateAllOrgDatasetConfigsReqPayload {
     /// The configuration to provide a filter on what datasets to update.
-    pub from_configuration: Option<serde_json::Value>,
+    pub match_configuration: Option<serde_json::Value>,
     /// The new configuration for all datasets in the organization. Only the specified keys in the configuration object will be changed per dataset such that you can preserve dataset unique values.
     pub to_configuration: serde_json::Value,
 }
@@ -474,12 +474,12 @@ pub async fn update_all_org_dataset_configs(
     let req_payload = req_payload.into_inner();
 
     let new_dataset_config = req_payload.to_configuration.clone();
-    let from_configuration = req_payload.from_configuration.clone();
+    let match_configuration = req_payload.match_configuration.clone();
 
     update_all_org_dataset_configs_query(
         organization_id,
         new_dataset_config,
-        from_configuration,
+        match_configuration,
         pool,
     )
     .await?;

--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -476,7 +476,13 @@ pub async fn update_all_org_dataset_configs(
     let new_dataset_config = req_payload.to_configuration.clone();
     let from_configuration = req_payload.from_configuration.clone();
 
-    update_all_org_dataset_configs_query(organization_id, new_dataset_config, from_configuration, pool).await?;
+    update_all_org_dataset_configs_query(
+        organization_id,
+        new_dataset_config,
+        from_configuration,
+        pool,
+    )
+    .await?;
 
     Ok(HttpResponse::NoContent().finish())
 }

--- a/server/src/operators/organization_operator.rs
+++ b/server/src/operators/organization_operator.rs
@@ -999,18 +999,21 @@ pub async fn update_all_org_dataset_configs_query(
     );
 
     if let Some(from_config) = from_config {
-        let from_config_query = from_config.as_object().unwrap().iter().map(|(key, value)| {
-            format!(
-                "server_configuration::jsonb->>'{}' = '{}'",
-                key,
-                value.as_str().unwrap().replace('\'', "''")
-            )
-        }).collect::<Vec<String>>().join(" AND ");
+        let from_config_query = from_config
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(key, value)| {
+                format!(
+                    "server_configuration::jsonb->>'{}' = '{}'",
+                    key,
+                    value.as_str().unwrap().replace('\'', "''")
+                )
+            })
+            .collect::<Vec<String>>()
+            .join(" AND ");
 
-        concat_configs_raw_query.push_str(&format!(
-            " AND ({})",
-            from_config_query
-        ));
+        concat_configs_raw_query.push_str(&format!(" AND ({})", from_config_query));
     }
 
     concat_configs_raw_query.push(';');

--- a/server/src/operators/organization_operator.rs
+++ b/server/src/operators/organization_operator.rs
@@ -1005,7 +1005,7 @@ pub async fn update_all_org_dataset_configs_query(
             .iter()
             .map(|(key, value)| {
                 format!(
-                    "server_configuration::jsonb->>'{}' = '{}'",
+                    "server_configuration::json->>'{}' = '{}'",
                     key,
                     value.as_str().unwrap().replace('\'', "''")
                 )

--- a/server/src/operators/organization_operator.rs
+++ b/server/src/operators/organization_operator.rs
@@ -990,7 +990,7 @@ pub async fn delete_actual_organization_query(
 pub async fn update_all_org_dataset_configs_query(
     org_id: uuid::Uuid,
     new_config: serde_json::Value,
-    from_config: Option<serde_json::Value>,
+    match_config: Option<serde_json::Value>,
     pool: web::Data<Pool>,
 ) -> Result<(), ServiceError> {
     let mut concat_configs_raw_query = format!(
@@ -998,8 +998,8 @@ pub async fn update_all_org_dataset_configs_query(
         new_config.to_string().replace('\'', "''"), org_id
     );
 
-    if let Some(from_config) = from_config {
-        let from_config_query = from_config
+    if let Some(match_config) = match_config {
+        let match_config_query = match_config
             .as_object()
             .unwrap()
             .iter()
@@ -1013,7 +1013,7 @@ pub async fn update_all_org_dataset_configs_query(
             .collect::<Vec<String>>()
             .join(" AND ");
 
-        concat_configs_raw_query.push_str(&format!(" AND ({})", from_config_query));
+        concat_configs_raw_query.push_str(&format!(" AND ({})", match_config_query));
     }
 
     concat_configs_raw_query.push(';');
@@ -1027,7 +1027,7 @@ pub async fn update_all_org_dataset_configs_query(
         .await
         .map_err(|e| {
             log::error!(
-                "Error updating datasets in update_all_org_dataset_server_configs: {:?}",
+                "Error updating datasets in update_all_org_dataset_configs: {:?}",
                 e
             );
             ServiceError::BadRequest("Error updating datasets".to_string())


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
**Example Request:** 
```
curl --request POST \
  --url http://localhost:8090/api/organization/update_dataset_configs \
  --header 'Authorization: tr-******************************' \
  --header 'Content-Type: application/json' \
  --header 'TR-Organization: ******************************' \
  --data '{
  "organization_id": "******************************",
  "from_configuration": {
    "LLM_DEFAULT_MODEL": "gpt-4o-mini"
  },
  "to_configuration": {
    "LLM_DEFAULT_MODEL": "gpt-4o",
    "SYSTEM_PROMPT": "You are a helpful assistant"
  }
}'
```