### PR TITLE
feature: enable accept-rfc-3339-timestamps in openidconnect-rs and skip tokenhash validation to enable auth0 compatability

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "openidconnect"
 version = "3.4.0"
-source = "git+https://github.com/devflowinc/openidconnect-rs.git?branch=patch-3.4.0#77e3d33960acf7650aeda3fdd9fac622f6814ee5"
+source = "git+https://github.com/devflowinc/openidconnect-rs.git?rev=9b9cefd91ae7e1bc4ad336a9bed5dcf04fa179a5#9b9cefd91ae7e1bc4ad336a9bed5dcf04fa179a5"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -153,8 +153,9 @@ utoipa = { version = "4.2", features = [
     "debug",
 ] }
 utoipa-redoc = { version = "4.0", features = ["actix-web"] }
-openidconnect = { git = "https://github.com/devflowinc/openidconnect-rs.git", branch = "patch-3.4.0",  features = [
+openidconnect = { git = "https://github.com/devflowinc/openidconnect-rs.git", rev = "9b9cefd91ae7e1bc4ad336a9bed5dcf04fa179a5",  features = [
     "reqwest",
+    "accept-rfc3339-timestamps"
 ], default-features = false }
 oauth2 = "4.4.2"
 dateparser = "0.2.1"


### PR DESCRIPTION
## Please indicate what issue this PR is related to and @ any maintainers who are relevant
