### PR TITLE
denzell/patch sync qdrant script

### DIFF
--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -5750,6 +5750,27 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "The cursor to start the pagination from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of items to return per page.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
           }
         ],
         "responses": {
@@ -7404,10 +7425,6 @@
             ],
             "nullable": true
           },
-          "metadata": {
-            "description": "Metadata is any metadata you want to associate w/ the event that is created from this request",
-            "nullable": true
-          },
           "page_size": {
             "type": "integer",
             "format": "int64",
@@ -8526,6 +8543,11 @@
             ],
             "nullable": true
           },
+          "fulltext_content": {
+            "type": "string",
+            "description": "If fulltext_content is present, it will be used for creating the fulltext and bm25 sparse vectors instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for semantic functionality unless the corresponding `semantic_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.",
+            "nullable": true
+          },
           "group_ids": {
             "type": "array",
             "items": {
@@ -8589,7 +8611,7 @@
           },
           "semantic_content": {
             "type": "string",
-            "description": "If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and always used for fulltext functionality. `chunk_html` must still be present for the chunk to be created properly.",
+            "description": "If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for fulltext functionality unless the corresponding `fulltext_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.",
             "nullable": true
           },
           "split_avg": {
@@ -12058,6 +12080,44 @@
             "items": {
               "type": "string"
             },
+            "nullable": true
+          }
+        }
+      },
+      "GetOrganizationApiKeysQuery": {
+        "type": "object",
+        "properties": {
+          "cursor": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The cursor to start the pagination from.",
+            "nullable": true
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of items to return per page.",
+            "nullable": true
+          }
+        }
+      },
+      "GetOrganizationApiKeysResponse": {
+        "type": "object",
+        "required": [
+          "api_keys"
+        ],
+        "properties": {
+          "api_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyRespBody"
+            },
+            "description": "The api keys which belong to the organization."
+          },
+          "cursor": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The cursor to start the pagination from.",
             "nullable": true
           }
         }
@@ -15574,6 +15634,10 @@
               "type"
             ],
             "properties": {
+              "count_collapsed_queries": {
+                "type": "boolean",
+                "nullable": true
+              },
               "filter": {
                 "allOf": [
                   {

--- a/clients/ts-sdk/openapi.json
+++ b/clients/ts-sdk/openapi.json
@@ -2259,6 +2259,82 @@
         ]
       }
     },
+    "/api/chunk_group/group_oriented_autocomplete": {
+      "post": {
+        "tags": [
+          "Group"
+        ],
+        "summary": "Autocomplete Search Over Groups",
+        "description": "This route provides the primary autocomplete functionality for the API. This prioritize prefix matching with semantic or full-text search.",
+        "operationId": "autocomplete_search_over_groups",
+        "parameters": [
+          {
+            "name": "TR-Dataset",
+            "in": "header",
+            "description": "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "X-API-Version",
+            "in": "header",
+            "description": "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/APIVersion"
+                }
+              ],
+              "nullable": true
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "JSON request payload to semantically search for groups",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutocompleteSearchOverGroupsReqPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Groups with embedding vectors which are similar to those in the request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchOverGroupsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Service error relating to searching",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [
+              "readonly"
+            ]
+          }
+        ]
+      }
+    },
     "/api/chunk_group/group_oriented_search": {
       "post": {
         "tags": [
@@ -7163,6 +7239,173 @@
                 "$ref": "#/components/schemas/HighlightOptions"
               }
             ],
+            "nullable": true
+          },
+          "page_size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Page size is the number of chunks to fetch. This can be used to fetch more than 10 chunks at a time.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "query": {
+            "$ref": "#/components/schemas/SearchModalities"
+          },
+          "remove_stop_words": {
+            "type": "boolean",
+            "description": "If true, stop words (specified in server/src/stop-words.txt in the git repo) will be removed. Queries that are entirely stop words will be preserved.",
+            "nullable": true
+          },
+          "score_threshold": {
+            "type": "number",
+            "format": "float",
+            "description": "Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.",
+            "nullable": true
+          },
+          "scoring_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScoringOptions"
+              }
+            ],
+            "nullable": true
+          },
+          "search_type": {
+            "$ref": "#/components/schemas/SearchMethod"
+          },
+          "slim_chunks": {
+            "type": "boolean",
+            "description": "Set slim_chunks to true to avoid returning the content and chunk_html of the chunks. This is useful for when you want to reduce amount of data over the wire for latency improvement (typically 10-50ms). Default is false.",
+            "nullable": true
+          },
+          "sort_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SortOptions"
+              }
+            ],
+            "nullable": true
+          },
+          "typo_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TypoOptions"
+              }
+            ],
+            "nullable": true
+          },
+          "use_quote_negated_terms": {
+            "type": "boolean",
+            "description": "If true, quoted and - prefixed words will be parsed from the queries and used as required and negated words respectively. Default is false.",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "string",
+            "description": "User ID is the id of the user who is making the request. This is used to track user interactions with the search results.",
+            "nullable": true
+          }
+        },
+        "example": {
+          "filters": {
+            "must": [
+              {
+                "field": "metadata.key2",
+                "match": [
+                  "value3",
+                  "value4"
+                ],
+                "range": {
+                  "gt": 0.0,
+                  "gte": 0.0,
+                  "lt": 1.0,
+                  "lte": 1.0
+                }
+              }
+            ],
+            "must_not": [
+              {
+                "field": "metadata.key3",
+                "match": [
+                  "value5",
+                  "value6"
+                ],
+                "range": {
+                  "gt": 0.0,
+                  "gte": 0.0,
+                  "lt": 1.0,
+                  "lte": 1.0
+                }
+              }
+            ],
+            "should": [
+              {
+                "field": "metadata.key1",
+                "match": [
+                  "value1",
+                  "value2"
+                ],
+                "range": {
+                  "gt": 0.0,
+                  "gte": 0.0,
+                  "lt": 1.0,
+                  "lte": 1.0
+                }
+              }
+            ]
+          },
+          "highlight_delimiters": [
+            "?",
+            ",",
+            ".",
+            "!"
+          ],
+          "highlight_results": true,
+          "page": 1,
+          "page_size": 10,
+          "query": "Some search query",
+          "recency_bias": 1.0,
+          "score_threshold": 0.5,
+          "search_type": "semantic",
+          "use_weights": true
+        }
+      },
+      "AutocompleteSearchOverGroupsReqPayload": {
+        "type": "object",
+        "required": [
+          "search_type",
+          "query"
+        ],
+        "properties": {
+          "extend_results": {
+            "type": "boolean",
+            "description": "If specified to true, this will extend the search results to include non-exact prefix matches of the same search_type such that a full page_size of results are returned. Default is false.",
+            "nullable": true
+          },
+          "filters": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChunkFilter"
+              }
+            ],
+            "nullable": true
+          },
+          "group_size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Group_size is the number of chunks to fetch for each group. The default is 3. If a group has less than group_size chunks, all chunks will be returned. If this is set to a large number, we recommend setting slim_chunks to true to avoid returning the content and chunk_html of the chunks so as to lower the amount of time required for content download and serialization.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "highlight_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HighlightOptions"
+              }
+            ],
+            "nullable": true
+          },
+          "metadata": {
+            "description": "Metadata is any metadata you want to associate w/ the event that is created from this request",
             "nullable": true
           },
           "page_size": {
@@ -15853,6 +16096,14 @@
             "description": "Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.",
             "nullable": true
           },
+          "scoring_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScoringOptions"
+              }
+            ],
+            "nullable": true
+          },
           "search_type": {
             "$ref": "#/components/schemas/SearchMethod"
           },
@@ -16267,6 +16518,14 @@
             "type": "number",
             "format": "float",
             "description": "Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.",
+            "nullable": true
+          },
+          "scoring_options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScoringOptions"
+              }
+            ],
             "nullable": true
           },
           "search_type": {

--- a/clients/ts-sdk/package.json
+++ b/clients/ts-sdk/package.json
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "version": "0.0.61",
+  "version": "0.0.98",
   "license": "MIT",
   "scripts": {
     "lint": "eslint 'src/**/*.ts'",

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -115,6 +115,52 @@ export type AutocompleteReqPayload = {
     user_id?: (string) | null;
 };
 
+export type AutocompleteSearchOverGroupsReqPayload = {
+    /**
+     * If specified to true, this will extend the search results to include non-exact prefix matches of the same search_type such that a full page_size of results are returned. Default is false.
+     */
+    extend_results?: (boolean) | null;
+    filters?: ((ChunkFilter) | null);
+    /**
+     * Group_size is the number of chunks to fetch for each group. The default is 3. If a group has less than group_size chunks, all chunks will be returned. If this is set to a large number, we recommend setting slim_chunks to true to avoid returning the content and chunk_html of the chunks so as to lower the amount of time required for content download and serialization.
+     */
+    group_size?: (number) | null;
+    highlight_options?: ((HighlightOptions) | null);
+    /**
+     * Metadata is any metadata you want to associate w/ the event that is created from this request
+     */
+    metadata?: unknown;
+    /**
+     * Page size is the number of chunks to fetch. This can be used to fetch more than 10 chunks at a time.
+     */
+    page_size?: (number) | null;
+    query: SearchModalities;
+    /**
+     * If true, stop words (specified in server/src/stop-words.txt in the git repo) will be removed. Queries that are entirely stop words will be preserved.
+     */
+    remove_stop_words?: (boolean) | null;
+    /**
+     * Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.
+     */
+    score_threshold?: (number) | null;
+    scoring_options?: ((ScoringOptions) | null);
+    search_type: SearchMethod;
+    /**
+     * Set slim_chunks to true to avoid returning the content and chunk_html of the chunks. This is useful for when you want to reduce amount of data over the wire for latency improvement (typically 10-50ms). Default is false.
+     */
+    slim_chunks?: (boolean) | null;
+    sort_options?: ((SortOptions) | null);
+    typo_options?: ((TypoOptions) | null);
+    /**
+     * If true, quoted and - prefixed words will be parsed from the queries and used as required and negated words respectively. Default is false.
+     */
+    use_quote_negated_terms?: (boolean) | null;
+    /**
+     * User ID is the id of the user who is making the request. This is used to track user interactions with the search results.
+     */
+    user_id?: (string) | null;
+};
+
 export type BatchQueuedChunkResponse = {
     chunk_metadata: Array<ChunkMetadata>;
 };
@@ -2940,6 +2986,7 @@ export type SearchOverGroupsReqPayload = {
      * Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.
      */
     score_threshold?: (number) | null;
+    scoring_options?: ((ScoringOptions) | null);
     search_type: SearchMethod;
     /**
      * Set slim_chunks to true to avoid returning the content and chunk_html of the chunks. This is useful for when you want to reduce amount of data over the wire for latency improvement (typicall 10-50ms). Default is false.
@@ -3071,6 +3118,7 @@ export type SearchWithinGroupReqPayload = {
      * Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.
      */
     score_threshold?: (number) | null;
+    scoring_options?: ((ScoringOptions) | null);
     search_type: SearchMethod;
     /**
      * Set slim_chunks to true to avoid returning the content and chunk_html of the chunks. This is useful for when you want to reduce amount of data over the wire for latency improvement (typicall 10-50ms). Default is false.
@@ -4201,6 +4249,23 @@ export type CountGroupChunksData = {
 };
 
 export type CountGroupChunksResponse = (GetChunkGroupCountResponse);
+
+export type AutocompleteSearchOverGroupsData = {
+    /**
+     * JSON request payload to semantically search for groups
+     */
+    requestBody: AutocompleteSearchOverGroupsReqPayload;
+    /**
+     * The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid.
+     */
+    trDataset: string;
+    /**
+     * The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.
+     */
+    xApiVersion?: ((APIVersion) | null);
+};
+
+export type AutocompleteSearchOverGroupsResponse = (SearchOverGroupsResponseBody);
 
 export type SearchOverGroupsData = {
     /**
@@ -5740,6 +5805,21 @@ export type $OpenApiTs = {
                  * Group not found
                  */
                 404: ErrorResponseBody;
+            };
+        };
+    };
+    '/api/chunk_group/group_oriented_autocomplete': {
+        post: {
+            req: AutocompleteSearchOverGroupsData;
+            res: {
+                /**
+                 * Groups with embedding vectors which are similar to those in the request body
+                 */
+                200: SearchOverGroupsResponseBody;
+                /**
+                 * Service error relating to searching
+                 */
+                400: ErrorResponseBody;
             };
         };
     };

--- a/clients/ts-sdk/src/types.gen.ts
+++ b/clients/ts-sdk/src/types.gen.ts
@@ -127,10 +127,6 @@ export type AutocompleteSearchOverGroupsReqPayload = {
     group_size?: (number) | null;
     highlight_options?: ((HighlightOptions) | null);
     /**
-     * Metadata is any metadata you want to associate w/ the event that is created from this request
-     */
-    metadata?: unknown;
-    /**
      * Page size is the number of chunks to fetch. This can be used to fetch more than 10 chunks at a time.
      */
     page_size?: (number) | null;
@@ -419,6 +415,10 @@ export type ChunkReqPayload = {
     convert_html_to_text?: (boolean) | null;
     fulltext_boost?: ((FullTextBoost) | null);
     /**
+     * If fulltext_content is present, it will be used for creating the fulltext and bm25 sparse vectors instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for semantic functionality unless the corresponding `semantic_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.
+     */
+    fulltext_content?: (string) | null;
+    /**
      * Group ids are the Trieve generated ids of the groups that the chunk should be placed into. This is useful for when you want to create a chunk and add it to a group or multiple groups in one request. Groups with these Trieve generated ids must be created first, it cannot be arbitrarily created through this route.
      */
     group_ids?: Array<(string)> | null;
@@ -449,7 +449,7 @@ export type ChunkReqPayload = {
     num_value?: (number) | null;
     semantic_boost?: ((SemanticBoost) | null);
     /**
-     * If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and always used for fulltext functionality. `chunk_html` must still be present for the chunk to be created properly.
+     * If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for fulltext functionality unless the corresponding `fulltext_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.
      */
     semantic_content?: (string) | null;
     /**
@@ -1849,6 +1849,28 @@ export type GetGroupsForChunksReqPayload = {
     chunk_tracking_ids?: Array<(string)> | null;
 };
 
+export type GetOrganizationApiKeysQuery = {
+    /**
+     * The cursor to start the pagination from.
+     */
+    cursor?: (string) | null;
+    /**
+     * The number of items to return per page.
+     */
+    limit?: (number) | null;
+};
+
+export type GetOrganizationApiKeysResponse = {
+    /**
+     * The api keys which belong to the organization.
+     */
+    api_keys: Array<ApiKeyRespBody>;
+    /**
+     * The cursor to start the pagination from.
+     */
+    cursor?: (string) | null;
+};
+
 export type GetPagefindIndexResponse = {
     url: string;
 };
@@ -2848,6 +2870,7 @@ export type SearchAnalytics = {
     sort_order?: ((SortOrder) | null);
     type: 'search_queries';
 } | {
+    count_collapsed_queries?: (boolean) | null;
     filter?: ((SearchAnalyticsFilter) | null);
     type: 'count_queries';
 } | {
@@ -4994,12 +5017,20 @@ export type UpdateOrganizationResponse = (Organization);
 
 export type GetOrganizationApiKeysData = {
     /**
+     * The cursor to start the pagination from.
+     */
+    cursor?: (string) | null;
+    /**
+     * The number of items to return per page.
+     */
+    limit?: (number) | null;
+    /**
      * The organization id to use for the request.
      */
     trOrganization: string;
 };
 
-export type GetOrganizationApiKeysResponse = (Array<ApiKeyRespBody>);
+export type GetOrganizationApiKeysResponse2 = (Array<ApiKeyRespBody>);
 
 export type CreateOrganizationApiKeyData = {
     /**

--- a/frontends/dashboard/package.json
+++ b/frontends/dashboard/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@nozbe/microfuzz": "^1.0.0",
-    "@sentry/browser": "^7.110.0",
     "@solidjs/router": "^0.10.1",
     "@tanstack/solid-query": "^5.55.4",
     "@tanstack/solid-query-devtools": "^5.55.4",

--- a/frontends/dashboard/src/components/ApiKeys.tsx
+++ b/frontends/dashboard/src/components/ApiKeys.tsx
@@ -12,7 +12,8 @@ import {
   getCoreRowModel,
 } from "@tanstack/solid-table";
 import { TanStackTable } from "shared/ui";
-import { ApiKeyRespBody } from "trieve-ts-sdk";
+import { ApiKeyRespBody, GetOrganizationApiKeysResponse } from "trieve-ts-sdk";
+import { PaginationArrows } from "./DatasetOverview";
 
 const colHelp = createColumnHelper<ApiKeyRespBody>();
 
@@ -33,13 +34,34 @@ export const ApiKeys = () => {
   });
 
   const trieve = useTrieve();
+  const [cursors, setCursors] = createSignal<(string | undefined)[]>([
+    undefined,
+  ]);
+
+  const [page, setPage] = createSignal<number>(0);
 
   const apiKeysQuery = createQuery(() => ({
     queryKey: ["apiKeys", userContext.selectedOrg().id],
-    queryFn: () => {
-      return trieve.fetch(`/api/organization/api_key`, "get", {
-        organizationId: userContext.selectedOrg().id,
+    queryFn: async () => {
+      const url =
+        page() === 0 || cursors()[page()] === undefined
+          ? "/api/organization/api_key"
+          : `/api/organization/api_key?cursor=${cursors()[page()]}`;
+
+      const response = (await trieve.fetch<"eject">(
+        //@ts-expect-error Argument of type '`/api/organization/api_key?cursor=${string}`' is not assignable to parameter of type 'keyof $OpenApiTs'.ts(2345)
+        url,
+        "get",
+        {
+          organizationId: userContext.selectedOrg().id,
+        },
+      )) as GetOrganizationApiKeysResponse;
+
+      setCursors((prevCursors) => {
+        return [...prevCursors, response.cursor as string];
       });
+
+      return response;
     },
   }));
 
@@ -134,7 +156,7 @@ export const ApiKeys = () => {
     ];
     return createSolidTable({
       columns: columns,
-      data: apiKeysQuery.data,
+      data: apiKeysQuery.data.api_keys as ApiKeyRespBody[],
       getCoreRowModel: getCoreRowModel(),
     });
   });
@@ -227,15 +249,39 @@ export const ApiKeys = () => {
             Create New Key +
           </button>
         </div>
-        <Show when={apiKeysQuery.data?.length === 0}>
+        <Show
+          when={(apiKeysQuery.data?.api_keys as ApiKeyRespBody[])?.length === 0}
+        >
           <div class="rounded-md border-[0.5px] border-neutral-300 bg-white py-4 text-center text-sm text-gray-500 shadow-sm">
             No API Keys
           </div>
         </Show>
-        <Show when={(apiKeysQuery.data?.length || -1) > 0}>
+        <Show
+          when={(apiKeysQuery.data?.api_keys as ApiKeyRespBody[])?.length > 0}
+        >
           <div class="inline-block w-full overflow-x-auto rounded-md border-[0.5px] border-neutral-300 bg-white align-middle shadow-sm">
             <Show when={table()}>
               {(table) => <TanStackTable table={table()} />}
+            </Show>
+            <Show
+              when={
+                (apiKeysQuery.data?.api_keys as ApiKeyRespBody[])?.length >=
+                  10 || cursors()[page()] !== undefined
+              }
+            >
+              <PaginationArrows
+                page={page}
+                setPage={(newPage) => {
+                  setPage(newPage);
+                  void apiKeysQuery.refetch();
+                }}
+                maxPageDiscovered={() => {
+                  return (apiKeysQuery.data?.api_keys as ApiKeyRespBody[])
+                    ?.length < 10
+                    ? page()
+                    : null;
+                }}
+              />
             </Show>
           </div>
         </Show>

--- a/frontends/dashboard/src/components/DatasetOverview.tsx
+++ b/frontends/dashboard/src/components/DatasetOverview.tsx
@@ -1,7 +1,6 @@
 import { TbDatabasePlus } from "solid-icons/tb";
 import {
   Show,
-  Setter,
   Accessor,
   createSignal,
   createEffect,
@@ -452,10 +451,10 @@ export const DatasetOverview = () => {
   );
 };
 
-const PaginationArrows = (props: {
+export const PaginationArrows = (props: {
   page: Accessor<number>;
-  setPage: Setter<number>;
-  maxPageDiscovered: Accessor<number | null>;
+  setPage: (page: number | ((page: number) => number)) => void;
+  maxPageDiscovered?: Accessor<number | null>;
 }) => {
   return (
     <div class="flex items-center justify-end gap-2 border-t border-t-neutral-200 p-1">
@@ -469,7 +468,9 @@ const PaginationArrows = (props: {
       <div class="text-sm">Page {props.page() + 1}</div>
       <button
         onClick={() => props.setPage((page) => page + 1)}
-        disabled={props.page() === props.maxPageDiscovered()}
+        disabled={
+          props.maxPageDiscovered && props.page() === props.maxPageDiscovered()
+        }
         class="p-2 text-lg font-semibold text-neutral-600 disabled:opacity-50"
       >
         <AiFillCaretRight />

--- a/frontends/dashboard/src/index.tsx
+++ b/frontends/dashboard/src/index.tsx
@@ -1,8 +1,7 @@
 /* @refresh reload */
 import "./index.css";
 import { render } from "solid-js/web";
-import * as Sentry from "@sentry/browser";
-import { DEV, Show } from "solid-js";
+import { Show } from "solid-js";
 import { Router, RouteDefinition } from "@solidjs/router";
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
 import { SolidQueryDevtools } from "@tanstack/solid-query-devtools";
@@ -40,23 +39,6 @@ import { SingleEventQueryPage } from "./analytics/pages/SingleEventQueryPage.tsx
 import { PublicPageSettingsPage } from "./pages/dataset/PublicPageSettings.tsx";
 import { CrawlOptionsTabs } from "./analytics/layouts/CrawlOptionsTabs.tsx";
 import { CrawlingHistory } from "./components/CrawlingHistory.tsx";
-
-if (!DEV) {
-  Sentry.init({
-    dsn: `${import.meta.env.VITE_SENTRY_DASHBOARD_DSN as string}`,
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
-    ],
-
-    tracesSampleRate: 1.0,
-
-    tracePropagationTargets: ["localhost", /^https:\/\/trieve\.ai\/api/],
-
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-  });
-}
 
 Chart.register(...registerables);
 

--- a/frontends/search/src/components/ResultsPage.tsx
+++ b/frontends/search/src/components/ResultsPage.tsx
@@ -433,6 +433,10 @@ const ResultsPage = (props: ResultsPageProps) => {
           searchRoute = "chunk/autocomplete";
           requestBody["extend_results"] =
             props.search.debounced.extendResults ?? false;
+          groupUnique = props.search.debounced.groupUniqueSearch;
+          if (groupUnique) {
+            searchRoute = "chunk_group/group_oriented_autocomplete";
+          }
         }
       }
 

--- a/frontends/search/src/components/SearchForm.tsx
+++ b/frontends/search/src/components/SearchForm.tsx
@@ -85,6 +85,16 @@ const SearchForm = (props: {
       isSelected: false,
       route: "semantic",
     },
+    {
+      name: "AutoComplete Semantic",
+      isSelected: false,
+      route: "autocomplete-semantic",
+    },
+    {
+      name: "AutoComplete FullText",
+      isSelected: false,
+      route: "autocomplete-fulltext",
+    },
   ];
 
   if (bm25Active) {
@@ -109,36 +119,6 @@ const SearchForm = (props: {
       value: "num_value",
     },
   ]);
-
-  createEffect(() => {
-    if (!props.search.state.groupUniqueSearch) {
-      console.log("groupUniqueSearch is false");
-
-      setSearchTypes((prev) => {
-        return prev.concat([
-          {
-            name: "AutoComplete Semantic",
-            isSelected: false,
-            route: "autocomplete-semantic",
-          },
-          {
-            name: "AutoComplete FullText",
-            isSelected: false,
-            route: "autocomplete-fulltext",
-          },
-        ]);
-      });
-    } else {
-      console.log("groupUniqueSearch is true");
-      setSearchTypes((prev) => {
-        return prev.filter(
-          (type) =>
-            type.route !== "autocomplete-semantic" &&
-            type.route !== "autocomplete-fulltext",
-        );
-      });
-    }
-  });
 
   const defaultRerankTypes = [
     {

--- a/server/Dockerfile.server
+++ b/server/Dockerfile.server
@@ -32,7 +32,7 @@ RUN apt-get update -y; \
     unzip \
     ;
 
-RUN curl -fsSLO https://github.com/subtrace/subtrace/releases/download/b267/subtrace-linux-amd64 \
+RUN curl -fsSLO https://github.com/subtrace/subtrace/releases/download/b314/subtrace-linux-amd64 \
     && chmod +x ./subtrace-linux-amd64
 
 RUN curl -L -o libtorch-cxx11-abi-shared-with-deps-2.4.0+cpu.zip https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.0%2Bcpu.zip \

--- a/server/src/bin/backfill-qdrant-from-pg.rs
+++ b/server/src/bin/backfill-qdrant-from-pg.rs
@@ -248,6 +248,7 @@ async fn main() -> Result<(), ServiceError> {
                                 let upload_message = ChunkReqPayload {
                                     chunk_html: chunk.chunk_html.clone(),
                                     semantic_content: None,
+                                    fulltext_content: None,
                                     link: chunk.link.clone(),
                                     tag_set: chunk.tag_set.clone().map(|tag_set| {
                                         tag_set.split(',').map(|tag| tag.to_string()).collect()

--- a/server/src/bin/crawl-worker.rs
+++ b/server/src/bin/crawl-worker.rs
@@ -794,6 +794,7 @@ async fn parse_youtube_chunks(
                     let create_chunk_data = ChunkReqPayload {
                         chunk_html: Some(transcript.text),
                         semantic_content: None,
+                        fulltext_content: None,
                         link: Some(format!(
                             "https://www.youtube.com/watch?v={}&t={}",
                             video.id.video_id,

--- a/server/src/bin/csv-jsonl-worker.rs
+++ b/server/src/bin/csv-jsonl-worker.rs
@@ -623,6 +623,7 @@ fn convert_value_to_chunkreqpayload(
     let mut chunk_req_payload = ChunkReqPayload {
         chunk_html,
         semantic_content: None,
+        fulltext_content: None,
         link: None,
         tag_set: None,
         num_value: None,

--- a/server/src/bin/file-worker.rs
+++ b/server/src/bin/file-worker.rs
@@ -459,6 +459,7 @@ async fn upload_file(
                         let create_chunk_data = ChunkReqPayload {
                             chunk_html: Some(page.content.clone()),
                             semantic_content: None,
+                            fulltext_content: None,
                             link: file_worker_message.upload_file_data.link.clone(),
                             tag_set: file_worker_message.upload_file_data.tag_set.clone(),
                             metadata,
@@ -575,6 +576,7 @@ async fn upload_file(
         let chunk = ChunkReqPayload {
             chunk_html: Some(html_content.clone()),
             semantic_content: None,
+            fulltext_content: None,
             link: file_worker_message.upload_file_data.link.clone(),
             tag_set: file_worker_message.upload_file_data.tag_set.clone(),
             metadata: file_worker_message.upload_file_data.metadata.clone(),
@@ -624,6 +626,7 @@ async fn upload_file(
         .map(|(i, chunk_html)| ChunkReqPayload {
             chunk_html: Some(chunk_html),
             semantic_content: None,
+            fulltext_content: None,
             link: file_worker_message.upload_file_data.link.clone(),
             tag_set: file_worker_message.upload_file_data.tag_set.clone(),
             metadata: file_worker_message.upload_file_data.metadata.clone(),

--- a/server/src/bin/sync-qdrant.rs
+++ b/server/src/bin/sync-qdrant.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<(), ServiceError> {
     let web_pool = actix_web::web::Data::new(pool.clone());
 
     let collections = get_qdrant_collections().await?;
+    let mut total = 0;
 
     for collection in collections {
         println!("starting on collection: {:?}", collection);
@@ -72,6 +73,8 @@ async fn main() -> Result<(), ServiceError> {
                 .map(|(_, x)| *x)
                 .collect::<Vec<uuid::Uuid>>();
 
+            total += qdrant_point_ids.len();
+
             if !qdrant_point_ids_not_in_pg.is_empty() {
                 println!(
                     "len of qdrant_point_ids_not_in_pg: {:?}, {:?}",
@@ -80,6 +83,8 @@ async fn main() -> Result<(), ServiceError> {
                 );
 
                 delete_points_from_qdrant(qdrant_point_ids_not_in_pg, collection.clone()).await?;
+            } else {
+                println!("Scrolled {}/{}", qdrant_point_ids.len(), total);
             }
 
             offset = new_offset;

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -17,6 +17,7 @@ use crate::handlers::message_handler::{
     CreateMessageReqPayload, EditMessageReqPayload, RegenerateMessageReqPayload,
 };
 
+use crate::handlers::group_handler::AutocompleteSearchOverGroupsReqPayload;
 use crate::handlers::page_handler::PublicPageParameters;
 use crate::operators::analytics_operator::{
     CTRRecommendationsWithClicksResponse, CTRRecommendationsWithoutClicksResponse,
@@ -4102,6 +4103,32 @@ impl ApiKeyRequestParams {
                 .or(payload.use_quote_negated_terms),
             remove_stop_words: self.remove_stop_words.or(payload.remove_stop_words),
             typo_options: self.typo_options.or(payload.typo_options),
+        }
+    }
+
+    pub fn combine_with_autocomplete_search_over_groups(
+        self,
+        payload: AutocompleteSearchOverGroupsReqPayload,
+    ) -> AutocompleteSearchOverGroupsReqPayload {
+        AutocompleteSearchOverGroupsReqPayload {
+            search_type: self.search_type.unwrap_or(payload.search_type),
+            extend_results: payload.extend_results,
+            query: payload.query,
+            page_size: self.page_size.or(payload.page_size),
+            filters: self.filters.or(payload.filters),
+            sort_options: payload.sort_options,
+            scoring_options: payload.scoring_options,
+            highlight_options: self.highlight_options.or(payload.highlight_options),
+            score_threshold: self.score_threshold.or(payload.score_threshold),
+            slim_chunks: self.slim_chunks.or(payload.slim_chunks),
+            use_quote_negated_terms: self
+                .use_quote_negated_terms
+                .or(payload.use_quote_negated_terms),
+            group_size: payload.group_size,
+            remove_stop_words: self.remove_stop_words.or(payload.remove_stop_words),
+            user_id: payload.user_id,
+            typo_options: self.typo_options.or(payload.typo_options),
+            metadata: payload.metadata,
         }
     }
 

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -4190,6 +4190,7 @@ impl ApiKeyRequestParams {
             user_id: payload.user_id,
             typo_options: self.typo_options.or(payload.typo_options),
             sort_options: payload.sort_options,
+            scoring_options: payload.scoring_options,
         }
     }
 
@@ -4217,6 +4218,7 @@ impl ApiKeyRequestParams {
             remove_stop_words: self.remove_stop_words.or(payload.remove_stop_words),
             user_id: payload.user_id,
             typo_options: self.typo_options.or(payload.typo_options),
+            scoring_options: payload.scoring_options,
         }
     }
 }
@@ -7799,6 +7801,7 @@ impl<'de> Deserialize<'de> for SearchWithinGroupReqPayload {
             remove_stop_words: Option<bool>,
             user_id: Option<String>,
             typo_options: Option<TypoOptions>,
+            scoring_options: Option<ScoringOptions>,
             #[serde(flatten)]
             other: std::collections::HashMap<String, serde_json::Value>,
         }
@@ -7832,6 +7835,7 @@ impl<'de> Deserialize<'de> for SearchWithinGroupReqPayload {
             remove_stop_words: helper.remove_stop_words,
             user_id: helper.user_id,
             typo_options: helper.typo_options,
+            scoring_options: helper.scoring_options,
         })
     }
 }
@@ -7858,6 +7862,7 @@ impl<'de> Deserialize<'de> for SearchOverGroupsReqPayload {
             user_id: Option<String>,
             typo_options: Option<TypoOptions>,
             sort_options: Option<SortOptions>,
+            scoring_options: Option<ScoringOptions>,
             #[serde(flatten)]
             other: std::collections::HashMap<String, serde_json::Value>,
         }
@@ -7888,6 +7893,7 @@ impl<'de> Deserialize<'de> for SearchOverGroupsReqPayload {
             sort_options,
             remove_stop_words: helper.remove_stop_words,
             user_id: helper.user_id,
+            scoring_options: helper.scoring_options,
         })
     }
 }

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6876,6 +6876,7 @@ pub enum SearchAnalytics {
     #[schema(title = "CountQueries")]
     CountQueries {
         filter: Option<SearchAnalyticsFilter>,
+        count_collapsed_queries: Option<bool>,
     },
     #[schema(title = "QueryDetails")]
     QueryDetails { request_id: uuid::Uuid },

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -4216,6 +4216,7 @@ impl ApiKeyRequestParams {
             remove_stop_words: self.remove_stop_words.or(payload.remove_stop_words),
             user_id: payload.user_id,
             typo_options: self.typo_options.or(payload.typo_options),
+            metadata: payload.metadata,
             sort_options: payload.sort_options,
             scoring_options: payload.scoring_options,
         }
@@ -7890,6 +7891,7 @@ impl<'de> Deserialize<'de> for SearchOverGroupsReqPayload {
             typo_options: Option<TypoOptions>,
             sort_options: Option<SortOptions>,
             scoring_options: Option<ScoringOptions>,
+            metadata: Option<serde_json::Value>,
             #[serde(flatten)]
             other: std::collections::HashMap<String, serde_json::Value>,
         }
@@ -7919,6 +7921,7 @@ impl<'de> Deserialize<'de> for SearchOverGroupsReqPayload {
             typo_options: helper.typo_options,
             sort_options,
             remove_stop_words: helper.remove_stop_words,
+            metadata: helper.metadata,
             user_id: helper.user_id,
             scoring_options: helper.scoring_options,
         })

--- a/server/src/data/models.rs
+++ b/server/src/data/models.rs
@@ -6132,6 +6132,7 @@ pub struct ChunkData {
     pub chunk_metadata: ChunkMetadata,
     pub content: String,
     pub embedding_content: String,
+    pub fulltext_content: String,
     pub group_ids: Option<Vec<uuid::Uuid>>,
     pub upsert_by_tracking_id: bool,
     pub fulltext_boost: Option<FullTextBoost>,

--- a/server/src/handlers/analytics_handler.rs
+++ b/server/src/handlers/analytics_handler.rs
@@ -281,10 +281,14 @@ pub async fn get_search_analytics(
 
             SearchAnalyticsResponse::QueryDetails(query)
         }
-        SearchAnalytics::CountQueries { filter } => {
+        SearchAnalytics::CountQueries {
+            filter,
+            count_collapsed_queries,
+        } => {
             let count_queries = get_query_counts_query(
                 dataset_org_plan_sub.dataset.id,
                 filter,
+                count_collapsed_queries,
                 clickhouse_client.get_ref(),
             )
             .await?;

--- a/server/src/handlers/chunk_handler.rs
+++ b/server/src/handlers/chunk_handler.rs
@@ -105,8 +105,10 @@ pub struct ScoringOptions {
 pub struct ChunkReqPayload {
     /// HTML content of the chunk. This can also be plaintext. The innerText of the HTML will be used to create the embedding vector. The point of using HTML is for convienience, as some users have applications where users submit HTML content.
     pub chunk_html: Option<String>,
-    /// If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and always used for fulltext functionality. `chunk_html` must still be present for the chunk to be created properly.
+    /// If semantic_content is present, it will be used for creating semantic embeddings instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for fulltext functionality unless the corresponding `fulltext_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.
     pub semantic_content: Option<String>,
+    /// If fulltext_content is present, it will be used for creating the fulltext and bm25 sparse vectors instead of the innerText `chunk_html`. `chunk_html` will still be the only thing stored and used for semantic functionality unless the corresponding `semantic_content` field is defined. `chunk_html` must still be present for the chunk to be created properly.
+    pub fulltext_content: Option<String>,
     /// Link to the chunk. This can also be any string. Frequently, this is a link to the source of the chunk. The link value will not affect the embedding creation.
     pub link: Option<String>,
     /// Tag set is a list of tags. This can be used to filter chunks by tag. Unlike with metadata filtering, HNSW indices will exist for each tag such that there is not a performance hit for filtering on them.

--- a/server/src/handlers/group_handler.rs
+++ b/server/src/handlers/group_handler.rs
@@ -1,16 +1,15 @@
 use super::{
     auth_handler::{AdminOnly, LoggedUser},
-    chunk_handler::{is_audio, ChunkFilter, SearchChunksReqPayload},
+    chunk_handler::{is_audio, ChunkFilter, ScoringOptions, SearchChunksReqPayload},
 };
 use crate::operators::chunk_operator::get_metadata_from_tracking_ids_query;
 use crate::{
     data::models::{
         escape_quotes, ChunkGroup, ChunkGroupAndFileId, ChunkGroupBookmark, ChunkMetadata,
         ChunkMetadataStringTagSet, DatasetAndOrgWithSubAndPlan, DatasetConfiguration,
-        HighlightOptions, MultiQuery, Pool, QueryTypes, RecommendType,
-        RecommendationEventClickhouse, RecommendationStrategy, RedisPool, ScoreChunk,
-        ScoreChunkDTO, SearchMethod, SearchQueryEventClickhouse, SortOptions, TypoOptions,
-        UnifiedId,
+        HighlightOptions, Pool, QueryTypes, RecommendType, RecommendationEventClickhouse,
+        RecommendationStrategy, RedisPool, ScoreChunk, ScoreChunkDTO, SearchMethod,
+        SearchQueryEventClickhouse, SortOptions, TypoOptions, UnifiedId,
     },
     errors::ServiceError,
     middleware::api_version::APIVersion,
@@ -24,9 +23,15 @@ use crate::{
         },
         search_operator::{
             get_metadata_from_groups, hybrid_search_over_groups, parse_query, search_groups_query,
-            search_hybrid_groups, search_over_groups_query, GroupScoreChunk, ParsedQuery,
-            ParsedQueryTypes, SearchOverGroupsQueryResult, SearchOverGroupsResults,
+            search_hybrid_groups, search_over_groups_query, GroupScoreChunk,
+            SearchOverGroupsQueryResult, SearchOverGroupsResults,
         },
+    },
+};
+use crate::{
+    data::models::{MultiQuery, SearchModalities},
+    operators::search_operator::{
+        autocomplete_search_over_groups_query, ParsedQuery, ParsedQueryTypes,
     },
 };
 use actix_web::{web, HttpResponse};
@@ -1387,8 +1392,8 @@ pub async fn get_recommended_groups(
 
     let group_qdrant_query_result = SearchOverGroupsQueryResult {
         search_results: recommended_groups_from_qdrant.clone(),
-        corrected_query: None,
         total_chunk_pages: (recommended_groups_from_qdrant.len() as f64 / 10.0).ceil() as i64,
+        batch_lengths: vec![],
     };
 
     timer.add("recommend_qdrant_groups_query");
@@ -1480,6 +1485,8 @@ pub struct SearchWithinGroupReqPayload {
     pub filters: Option<ChunkFilter>,
     /// Group specifies the group to search within. Results will only consist of chunks which are bookmarks within the specified group.
     pub group_id: Option<uuid::Uuid>,
+    /// Scoring options provides ways to modify the sparse or dense vector created for the query in order to change how potential matches are scored. If not specified, this defaults to no modifications.
+    pub scoring_options: Option<ScoringOptions>,
     /// Group_tracking_id specifies the group to search within by tracking id. Results will only consist of chunks which are bookmarks within the specified group. If both group_id and group_tracking_id are provided, group_id will be used.
     pub group_tracking_id: Option<String>,
     /// Search_type can be either "semantic", "fulltext", or "hybrid". "hybrid" will pull in one page (10 chunks) of both semantic and full-text results then re-rank them using scores from a cross encoder model. "semantic" will pull in one page (10 chunks) of the nearest cosine distant vectors. "fulltext" will pull in one page (10 chunks) of full-text results based on SPLADE.
@@ -1666,6 +1673,10 @@ pub async fn search_within_group(
         .unwrap_or_default(),
     };
 
+    if query.is_empty() {
+        return Err(ServiceError::BadRequest("Query cannot be empty".to_string()).into());
+    }
+
     let result_chunks = match data.search_type {
         SearchMethod::Hybrid => {
             search_hybrid_groups(
@@ -1762,6 +1773,8 @@ pub struct SearchOverGroupsReqPayload {
     pub get_total_pages: Option<bool>,
     /// Filters is a JSON object which can be used to filter chunks. The values on each key in the object will be used to check for an exact substring match on the metadata values for each existing chunk. This is useful for when you want to filter chunks by arbitrary metadata. Unlike with tag filtering, there is a performance hit for filtering on metadata.
     pub filters: Option<ChunkFilter>,
+    /// Scoring options provides ways to modify the sparse or dense vector created for the query in order to change how potential matches are scored. If not specified, this defaults to no modifications.
+    pub scoring_options: Option<ScoringOptions>,
     /// Highlight Options lets you specify different methods to highlight the chunks in the result set. If not specified, this defaults to the score of the chunks.
     pub highlight_options: Option<HighlightOptions>,
     /// Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.
@@ -1938,6 +1951,227 @@ pub async fn search_over_groups(
             .insert_header((
                 "X-TR-Query",
                 query.replace(|c: char| c.is_ascii_control(), ""),
+            ))
+            .json(result_chunks.into_v2(search_id)));
+    } else {
+        return Ok(HttpResponse::Ok()
+            .insert_header((Timer::header_key(), timer.header_value()))
+            .json(result_chunks.into_v2(search_id)));
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[schema(example = json!({
+    "search_type": "semantic",
+    "query": "Some search query",
+    "page": 1,
+    "page_size": 10,
+    "filters": {
+        "should": [
+            {
+                "field": "metadata.key1",
+                "match": ["value1", "value2"],
+                "range": {
+                    "gte": 0.0,
+                    "lte": 1.0,
+                    "gt": 0.0,
+                    "lt": 1.0
+                }
+            }
+        ],
+        "must": [
+            {
+                "field": "metadata.key2",
+                "match": ["value3", "value4"],
+                "range": {
+                    "gte": 0.0,
+                    "lte": 1.0,
+                    "gt": 0.0,
+                    "lt": 1.0
+                }
+            }
+        ],
+        "must_not": [
+            {
+                "field": "metadata.key3",
+                "match": ["value5", "value6"],
+                "range": {
+                    "gte": 0.0,
+                    "lte": 1.0,
+                    "gt": 0.0,
+                    "lt": 1.0
+                }
+            }
+        ]
+    },
+    "recency_bias": 1.0,
+    "use_weights": true,
+    "highlight_results": true,
+    "highlight_delimiters": ["?", ",", ".", "!"],
+    "score_threshold": 0.5
+}))]
+pub struct AutocompleteSearchOverGroupsReqPayload {
+    /// Can be either "semantic", or "fulltext". "semantic" will pull in one page_size of the nearest cosine distant vectors. "fulltext" will pull in one page_size of full-text results based on SPLADE. "bm25" will pull in one page_size of results based on the BM25 algorithim
+    pub search_type: SearchMethod,
+    /// If specified to true, this will extend the search results to include non-exact prefix matches of the same search_type such that a full page_size of results are returned. Default is false.
+    pub extend_results: Option<bool>,
+    /// Query is the search query. This can be any string. The query will be used to create an embedding vector and/or SPLADE vector which will be used to find the result set.
+    pub query: SearchModalities,
+    /// Page size is the number of chunks to fetch. This can be used to fetch more than 10 chunks at a time.
+    pub page_size: Option<u64>,
+    /// Filters is a JSON object which can be used to filter chunks. This is useful for when you want to filter chunks by arbitrary metadata. Unlike with tag filtering, there is a performance hit for filtering on metadata.
+    pub filters: Option<ChunkFilter>,
+    /// Sort Options lets you specify different methods to rerank the chunks in the result set. If not specified, this defaults to the score of the chunks.
+    pub sort_options: Option<SortOptions>,
+    /// Group_size is the number of chunks to fetch for each group. The default is 3. If a group has less than group_size chunks, all chunks will be returned. If this is set to a large number, we recommend setting slim_chunks to true to avoid returning the content and chunk_html of the chunks so as to lower the amount of time required for content download and serialization.
+    pub group_size: Option<u64>,
+    /// Scoring options provides ways to modify the sparse or dense vector created for the query in order to change how potential matches are scored. If not specified, this defaults to no modifications.
+    pub scoring_options: Option<ScoringOptions>,
+    /// Highlight Options lets you specify different methods to highlight the chunks in the result set. If not specified, this defaults to the score of the chunks.
+    pub highlight_options: Option<HighlightOptions>,
+    /// Set score_threshold to a float to filter out chunks with a score below the threshold. This threshold applies before weight and bias modifications. If not specified, this defaults to 0.0.
+    pub score_threshold: Option<f32>,
+    /// Set slim_chunks to true to avoid returning the content and chunk_html of the chunks. This is useful for when you want to reduce amount of data over the wire for latency improvement (typically 10-50ms). Default is false.
+    pub slim_chunks: Option<bool>,
+    /// If true, quoted and - prefixed words will be parsed from the queries and used as required and negated words respectively. Default is false.
+    pub use_quote_negated_terms: Option<bool>,
+    /// If true, stop words (specified in server/src/stop-words.txt in the git repo) will be removed. Queries that are entirely stop words will be preserved.
+    pub remove_stop_words: Option<bool>,
+    /// User ID is the id of the user who is making the request. This is used to track user interactions with the search results.
+    pub user_id: Option<String>,
+    /// If true, the query will be corrected for typos. Default is false.
+    pub typo_options: Option<TypoOptions>,
+}
+
+impl From<AutocompleteSearchOverGroupsReqPayload> for SearchOverGroupsReqPayload {
+    fn from(value: AutocompleteSearchOverGroupsReqPayload) -> Self {
+        SearchOverGroupsReqPayload {
+            page: Some(1),
+            query: QueryTypes::Single(value.clone().query),
+            page_size: value.page_size,
+            filters: value.filters,
+            sort_options: value.sort_options,
+            group_size: value.group_size,
+            scoring_options: value.scoring_options,
+            highlight_options: value.highlight_options,
+            score_threshold: value.score_threshold,
+            slim_chunks: value.slim_chunks,
+            use_quote_negated_terms: value.use_quote_negated_terms,
+            remove_stop_words: value.remove_stop_words,
+            user_id: value.user_id,
+            typo_options: value.typo_options,
+            get_total_pages: Some(false),
+            search_type: value.search_type,
+        }
+    }
+}
+
+/// Autocomplete Search Over Groups
+///
+/// This route provides the primary autocomplete functionality for the API. This prioritize prefix matching with semantic or full-text search.
+#[utoipa::path(
+    post,
+    path = "/chunk_group/group_oriented_autocomplete",
+    context_path = "/api",
+    tag = "Group",
+    request_body(content = AutocompleteSearchOverGroupsReqPayload, description = "JSON request payload to semantically search for groups", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Groups with embedding vectors which are similar to those in the request body", body = SearchOverGroupsResponseBody),
+        (status = 400, description = "Service error relating to searching", body = ErrorResponseBody),
+    ),
+    params(
+        ("TR-Dataset" = uuid::Uuid, Header, description = "The dataset id or tracking_id to use for the request. We assume you intend to use an id if the value is a valid uuid."),
+        ("X-API-Version" = Option<APIVersion>, Header, description = "The API version to use for this request. Defaults to V2 for orgs created after July 12, 2024 and V1 otherwise.")
+    ),
+    security(
+        ("ApiKey" = ["readonly"]),
+    )
+)]
+pub async fn autocomplete_search_over_groups(
+    data: web::Json<AutocompleteSearchOverGroupsReqPayload>,
+    _user: LoggedUser,
+    pool: web::Data<Pool>,
+    event_queue: web::Data<EventQueue>,
+    redis_pool: web::Data<RedisPool>,
+    api_version: APIVersion,
+    dataset_org_plan_sub: DatasetAndOrgWithSubAndPlan,
+) -> Result<HttpResponse, actix_web::Error> {
+    let dataset_config =
+        DatasetConfiguration::from_json(dataset_org_plan_sub.dataset.server_configuration.clone());
+
+    let parsed_query = parse_query(
+        data.query.clone(),
+        &dataset_org_plan_sub.dataset,
+        data.use_quote_negated_terms,
+        data.remove_stop_words,
+    )
+    .await?;
+
+    if parsed_query.query.is_empty() {
+        return Err(ServiceError::BadRequest("Query cannot be empty".to_string()).into());
+    }
+
+    let mut timer = Timer::new();
+
+    let result_chunks = autocomplete_search_over_groups_query(
+        data.clone(),
+        parsed_query.clone(),
+        pool,
+        redis_pool,
+        dataset_org_plan_sub.dataset.clone(),
+        &dataset_config,
+        &mut timer,
+    )
+    .await?;
+
+    timer.add("autocomplete_chunks");
+
+    let search_id = uuid::Uuid::new_v4();
+    if !dataset_config.DISABLE_ANALYTICS {
+        let clickhouse_event = SearchQueryEventClickhouse {
+            id: search_id,
+            search_type: String::from("autocomplete"),
+            query: parsed_query.query.clone(),
+            request_params: serde_json::to_string(&data.clone()).unwrap_or_default(),
+            latency: get_latency_from_header(timer.header_value()),
+            top_score: result_chunks
+                .group_chunks
+                .first()
+                .map(|x| x.metadata.first().map(|y| y.score as f32).unwrap_or(0.0))
+                .unwrap_or(0.0),
+            results: result_chunks
+                .group_chunks
+                .clone()
+                .into_iter()
+                .map(|x| {
+                    let mut json = serde_json::to_value(&x).unwrap_or_default();
+                    escape_quotes(&mut json);
+                    json.to_string()
+                })
+                .collect(),
+            dataset_id: dataset_org_plan_sub.dataset.id,
+            created_at: time::OffsetDateTime::now_utc(),
+            query_rating: String::from(""),
+            user_id: data.user_id.clone().unwrap_or_default(),
+        };
+
+        event_queue
+            .send(ClickHouseEvent::SearchQueryEvent(clickhouse_event))
+            .await;
+    }
+
+    timer.add("send_to_clickhouse");
+
+    if api_version == APIVersion::V1 {
+        Ok(HttpResponse::Ok().json(result_chunks))
+    } else if is_audio(QueryTypes::Single(data.query.clone())) {
+        return Ok(HttpResponse::Ok()
+            .insert_header((Timer::header_key(), timer.header_value()))
+            .insert_header((
+                "X-TR-Query",
+                parsed_query
+                    .query
+                    .replace(|c: char| c.is_ascii_control(), ""),
             ))
             .json(result_chunks.into_v2(search_id)));
     } else {

--- a/server/src/handlers/group_handler.rs
+++ b/server/src/handlers/group_handler.rs
@@ -1793,6 +1793,7 @@ pub struct SearchOverGroupsReqPayload {
     /// The user_id is the id of the user who is making the request. This is used to track user interactions with the search results.
     pub user_id: Option<String>,
     pub typo_options: Option<TypoOptions>,
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Search Over Groups
@@ -2041,6 +2042,8 @@ pub struct AutocompleteSearchOverGroupsReqPayload {
     pub user_id: Option<String>,
     /// If true, the query will be corrected for typos. Default is false.
     pub typo_options: Option<TypoOptions>,
+    /// Metadata is any metadata you want to associate w/ the event that is created from this request
+    pub metadata: Option<serde_json::Value>,
 }
 
 impl From<AutocompleteSearchOverGroupsReqPayload> for SearchOverGroupsReqPayload {
@@ -2060,6 +2063,7 @@ impl From<AutocompleteSearchOverGroupsReqPayload> for SearchOverGroupsReqPayload
             remove_stop_words: value.remove_stop_words,
             user_id: value.user_id,
             typo_options: value.typo_options,
+            metadata: value.metadata,
             get_total_pages: Some(false),
             search_type: value.search_type,
         }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -224,6 +224,7 @@ impl Modify for SecurityAddon {
         handlers::group_handler::get_chunks_in_group_by_tracking_id,
         handlers::group_handler::search_within_group,
         handlers::file_handler::get_dataset_files_handler,
+        handlers::group_handler::autocomplete_search_over_groups,
         handlers::file_handler::upload_file_handler,
         handlers::file_handler::get_file_handler,
         handlers::file_handler::delete_file_handler,
@@ -366,6 +367,7 @@ impl Modify for SecurityAddon {
             handlers::group_handler::AddChunkToGroupReqPayload,
             handlers::group_handler::RecommendGroupsResponseBody,
             handlers::user_handler::UpdateUserOrgRoleReqPayload,
+            handlers::group_handler::AutocompleteSearchOverGroupsReqPayload,
             handlers::organization_handler::CreateApiKeyReqPayload,
             handlers::organization_handler::CreateApiKeyResponse,
             operators::group_operator::GroupsForChunk,
@@ -1122,6 +1124,12 @@ pub fn main() -> std::io::Result<()> {
                                 .service(
                                     web::resource("/group_oriented_search").route(
                                         web::post().to(handlers::group_handler::search_over_groups),
+                                    )
+                                    .wrap(Compress::default())
+                                )
+                                .service(
+                                    web::resource("/group_oriented_autocomplete").route(
+                                        web::post().to(handlers::group_handler::autocomplete_search_over_groups),
                                     )
                                     .wrap(Compress::default())
                                 )

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -383,6 +383,8 @@ impl Modify for SecurityAddon {
             handlers::organization_handler::CreateOrganizationReqPayload,
             handlers::organization_handler::UpdateOrganizationReqPayload,
             handlers::organization_handler::UpdateAllOrgDatasetConfigsReqPayload,
+            handlers::organization_handler::GetOrganizationApiKeysQuery,
+            handlers::organization_handler::GetOrganizationApiKeysResponse,
             operators::event_operator::EventReturn,
             operators::search_operator::DeprecatedSearchOverGroupsResponseBody,
             operators::search_operator::GroupScoreChunk,

--- a/server/src/middleware/auth_middleware.rs
+++ b/server/src/middleware/auth_middleware.rs
@@ -6,7 +6,10 @@ use crate::{
     handlers::{
         auth_handler::{AdminOnly, LoggedUser, OrganizationRole, OwnerOnly},
         chunk_handler::{AutocompleteReqPayload, ScrollChunksReqPayload, SearchChunksReqPayload},
-        group_handler::{SearchOverGroupsReqPayload, SearchWithinGroupReqPayload},
+        group_handler::{
+            AutocompleteSearchOverGroupsReqPayload, SearchOverGroupsReqPayload,
+            SearchWithinGroupReqPayload,
+        },
         message_handler::CreateMessageReqPayload,
     },
     operators::{
@@ -388,6 +391,15 @@ pub async fn insert_api_key_payload(
         "/api/chunk_group/group_oriented_search" => {
             let body = req.extract::<Json<SearchOverGroupsReqPayload>>().await?;
             let new_body = api_key_params.combine_with_search_over_groups(body.into_inner());
+            let body_bytes = serde_json::to_vec(&web::Json(new_body)).unwrap();
+            req.set_payload(bytes_to_payload(body_bytes.into()));
+        }
+        "/api/chunk_group/group_oriented_autocomplete" => {
+            let body = req
+                .extract::<Json<AutocompleteSearchOverGroupsReqPayload>>()
+                .await?;
+            let new_body =
+                api_key_params.combine_with_autocomplete_search_over_groups(body.into_inner());
             let body_bytes = serde_json::to_vec(&web::Json(new_body)).unwrap();
             req.set_payload(bytes_to_payload(body_bytes.into()));
         }

--- a/server/src/operators/chunk_operator.rs
+++ b/server/src/operators/chunk_operator.rs
@@ -773,6 +773,7 @@ pub async fn bulk_insert_chunk_metadata_query(
                 chunk_metadata,
                 content: chunk_data.content,
                 embedding_content: chunk_data.embedding_content,
+                fulltext_content: chunk_data.fulltext_content,
                 group_ids: chunk_data.group_ids,
                 upsert_by_tracking_id: chunk_data.upsert_by_tracking_id,
                 fulltext_boost: chunk_data.fulltext_boost,

--- a/server/src/operators/model_operator.rs
+++ b/server/src/operators/model_operator.rs
@@ -895,7 +895,11 @@ pub async fn cross_encoder(
         "RERANKER_SERVER_ORIGIN",
         "RERANKER_SERVER_ORIGIN must be set"
     );
-    let server_origin: String = dataset_config.RERANKER_BASE_URL.clone();
+    let mut server_origin: String = dataset_config.RERANKER_BASE_URL.clone();
+
+    if server_origin == "http://embedding-reranker.default.svc.cluster.local" {
+        server_origin = default_server_origin.to_string();
+    }
 
     let embedding_server_call = format!("{}/rerank", server_origin);
 

--- a/server/src/operators/search_operator.rs
+++ b/server/src/operators/search_operator.rs
@@ -3071,6 +3071,11 @@ pub async fn autocomplete_search_over_groups_query(
         data.sort_options,
     ));
 
+    reranked_chunks = reranked_chunks
+        .into_iter()
+        .dedup_by(|a, b| a.group_id == b.group_id)
+        .collect::<Vec<GroupScoreChunk>>();
+
     reranked_chunks.truncate(data.page_size.unwrap_or(10) as usize);
 
     result_chunks.group_chunks = reranked_chunks;

--- a/server/src/operators/search_operator.rs
+++ b/server/src/operators/search_operator.rs
@@ -27,7 +27,8 @@ use crate::handlers::chunk_handler::{
     ScoringOptions, SearchChunkQueryResponseBody, SearchChunksReqPayload,
 };
 use crate::handlers::group_handler::{
-    SearchOverGroupsReqPayload, SearchWithinGroupReqPayload, SearchWithinGroupResults,
+    AutocompleteSearchOverGroupsReqPayload, SearchOverGroupsReqPayload,
+    SearchWithinGroupReqPayload, SearchWithinGroupResults,
 };
 use crate::operators::qdrant_operator::search_qdrant_query;
 use crate::{
@@ -1177,8 +1178,8 @@ pub async fn get_group_tag_set_filter_condition(
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SearchOverGroupsQueryResult {
     pub search_results: Vec<GroupSearchResults>,
-    pub corrected_query: Option<String>,
     pub total_chunk_pages: i64,
+    pub batch_lengths: Vec<usize>,
 }
 
 pub async fn retrieve_group_qdrant_points_query(
@@ -1190,7 +1191,7 @@ pub async fn retrieve_group_qdrant_points_query(
 ) -> Result<SearchOverGroupsQueryResult, ServiceError> {
     let page = if page == 0 { 1 } else { page };
     let use_mmr = mmr_options.is_some_and(|mmr| mmr.use_mmr && mmr.mmr_lambda.unwrap_or(0.5) > 0.0);
-    let (point_ids, count) = search_over_groups_qdrant_query(
+    let (point_ids, count, batch_lengths) = search_over_groups_qdrant_query(
         page,
         qdrant_searches.clone(),
         config.clone(),
@@ -1210,7 +1211,7 @@ pub async fn retrieve_group_qdrant_points_query(
     Ok(SearchOverGroupsQueryResult {
         search_results: point_ids,
         total_chunk_pages: pages,
-        corrected_query: None,
+        batch_lengths,
     })
 }
 
@@ -2599,8 +2600,13 @@ pub async fn search_groups_query(
     config: &DatasetConfiguration,
     timer: &mut Timer,
 ) -> Result<SearchWithinGroupResults, actix_web::Error> {
-    let vector =
-        get_qdrant_vector(data.clone().search_type, parsed_query.clone(), None, config).await?;
+    let vector = get_qdrant_vector(
+        data.clone().search_type,
+        parsed_query.clone(),
+        data.clone().scoring_options,
+        config,
+    )
+    .await?;
 
     let mut parsed_query = parsed_query.clone();
     let mut corrected_query = None;
@@ -2748,14 +2754,26 @@ pub async fn search_hybrid_groups(
         timer.add("corrected query");
     }
 
+    let semantic_boost = data
+        .scoring_options
+        .clone()
+        .map(|options| options.semantic_boost)
+        .unwrap_or(None);
+    let fulltext_boost = data
+        .scoring_options
+        .clone()
+        .map(|options| options.fulltext_boost)
+        .unwrap_or(None);
+
     let dense_vector_future = get_dense_vector(
         parsed_query.query.clone(),
-        None,
+        semantic_boost,
         "query",
         dataset_config.clone(),
     );
 
-    let sparse_vector_future = get_sparse_vector(parsed_query.query.clone(), None, "query");
+    let sparse_vector_future =
+        get_sparse_vector(parsed_query.query.clone(), fulltext_boost, "query");
 
     let (dense_vector, sparse_vector) =
         futures::try_join!(dense_vector_future, sparse_vector_future)?;
@@ -2897,6 +2915,171 @@ pub async fn search_hybrid_groups(
     })
 }
 
+pub async fn autocomplete_search_over_groups_query(
+    mut data: AutocompleteSearchOverGroupsReqPayload,
+    parsed_query: ParsedQuery,
+    pool: web::Data<Pool>,
+    redis_pool: web::Data<RedisPool>,
+    dataset: Dataset,
+    config: &DatasetConfiguration,
+    timer: &mut Timer,
+) -> Result<DeprecatedSearchOverGroupsResponseBody, actix_web::Error> {
+    let mut parsed_query = parsed_query.clone();
+    let mut corrected_query = None;
+
+    if let Some(options) = &data.typo_options {
+        timer.add("start correcting query");
+        let typo_corrected_query =
+            correct_query(parsed_query.clone(), dataset.id, redis_pool, options).await?;
+        if typo_corrected_query.corrected {
+            corrected_query.clone_from(&typo_corrected_query.query);
+        }
+        parsed_query = typo_corrected_query
+            .query
+            .clone()
+            .unwrap_or(parsed_query.clone());
+        data.query = SearchModalities::Text(parsed_query.query.clone());
+        timer.add("corrected query");
+    }
+
+    let vector = get_qdrant_vector(
+        data.clone().search_type,
+        ParsedQueryTypes::Single(parsed_query.clone()),
+        data.clone().scoring_options,
+        config,
+    )
+    .await?;
+    timer.add("computed dense embedding");
+
+    let (sort_by, rerank_by) = match data.sort_options.as_ref().map(|d| d.sort_by.clone()) {
+        Some(Some(sort_by)) => match sort_by {
+            QdrantSortBy::Field(field) => (Some(field.clone()), None),
+            QdrantSortBy::SearchType(search_type) => (None, Some(search_type)),
+        },
+        _ => (None, None),
+    };
+
+    let mut qdrant_query = vec![
+        RetrievePointQuery {
+            vector: vector.clone(),
+            score_threshold: if rerank_by.clone().map(|r| r.rerank_type)
+                == Some(ReRankOptions::CrossEncoder)
+            {
+                None
+            } else {
+                data.score_threshold
+            },
+            limit: data.page_size.unwrap_or(10),
+            sort_by: sort_by.clone(),
+            rerank_by: rerank_by.clone(),
+            filter: data.filters.clone(),
+            group_size: data.group_size,
+        }
+        .into_qdrant_query(
+            ParsedQueryTypes::Single(parsed_query.clone()),
+            dataset.id,
+            None,
+            config,
+            pool.clone(),
+        )
+        .await?,
+    ];
+
+    if let Some(q) = qdrant_query.get_mut(0) {
+        q.filter.must.push(Condition::matches_text(
+            "content",
+            parsed_query.query.clone(),
+        ));
+    }
+
+    if data.extend_results.unwrap_or(false) {
+        qdrant_query.push(
+            RetrievePointQuery {
+                vector,
+                score_threshold: data.score_threshold,
+                sort_by: sort_by.clone(),
+                rerank_by: rerank_by.clone(),
+                limit: data.page_size.unwrap_or(10),
+                filter: data.filters.clone(),
+                group_size: data.group_size,
+            }
+            .into_qdrant_query(
+                ParsedQueryTypes::Single(parsed_query.clone()),
+                dataset.id,
+                None,
+                config,
+                pool.clone(),
+            )
+            .await?,
+        );
+    };
+
+    let search_over_groups_qdrant_result = retrieve_group_qdrant_points_query(
+        qdrant_query,
+        1,
+        data.sort_options.as_ref().and_then(|d| d.mmr.clone()),
+        false,
+        config,
+    )
+    .await?;
+
+    timer.add("fetched from qdrant");
+
+    let mut result_chunks = retrieve_chunks_for_groups(
+        search_over_groups_qdrant_result.clone(),
+        &data.clone().into(),
+        pool.clone(),
+    )
+    .await?;
+
+    result_chunks.group_chunks = search_over_groups_qdrant_result
+        .search_results
+        .iter()
+        .filter_map(|search_result| {
+            result_chunks
+                .group_chunks
+                .iter()
+                .find(|group| group.group_id == search_result.group_id)
+                .cloned()
+        })
+        .collect();
+
+    timer.add("fetched from postgres");
+
+    let first_increase = *search_over_groups_qdrant_result
+        .batch_lengths
+        .get(0)
+        .unwrap_or(&0) as usize;
+
+    let (before_increase, after_increase) = if first_increase < result_chunks.group_chunks.len() {
+        result_chunks.group_chunks.split_at(first_increase)
+    } else {
+        let empty_vec: &[GroupScoreChunk] = &[];
+
+        (result_chunks.group_chunks.as_slice(), empty_vec)
+    };
+
+    let mut reranked_chunks = rerank_groups(
+        before_increase.to_vec(),
+        search_over_groups_qdrant_result.search_results.clone(),
+        data.sort_options.clone(),
+    );
+
+    reranked_chunks.extend(rerank_groups(
+        after_increase.to_vec(),
+        search_over_groups_qdrant_result.search_results,
+        data.sort_options,
+    ));
+
+    reranked_chunks.truncate(data.page_size.unwrap_or(10) as usize);
+
+    result_chunks.group_chunks = reranked_chunks;
+
+    result_chunks.corrected_query = corrected_query.map(|c| c.query);
+
+    Ok(result_chunks)
+}
+
 pub async fn search_over_groups_query(
     mut data: SearchOverGroupsReqPayload,
     parsed_query: ParsedQueryTypes,
@@ -2938,8 +3121,13 @@ pub async fn search_over_groups_query(
         timer.add("corrected query");
     }
 
-    let vector =
-        get_qdrant_vector(data.clone().search_type, parsed_query.clone(), None, config).await?;
+    let vector = get_qdrant_vector(
+        data.clone().search_type,
+        parsed_query.clone(),
+        data.clone().scoring_options,
+        config,
+    )
+    .await?;
 
     timer.add("computed dense embedding");
 
@@ -3088,15 +3276,26 @@ pub async fn hybrid_search_over_groups(
         timer.add("corrected query");
     }
 
+    let semantic_boost = data
+        .scoring_options
+        .clone()
+        .map(|options| options.semantic_boost)
+        .unwrap_or(None);
+    let fulltext_boost = data
+        .scoring_options
+        .clone()
+        .map(|options| options.fulltext_boost)
+        .unwrap_or(None);
+
     let dense_embedding_vectors_future = get_dense_vector(
         parsed_query.query.clone(),
-        None,
+        semantic_boost,
         "query",
         dataset_config.clone(),
     );
 
     let sparse_embedding_vector_future =
-        get_sparse_vector(parsed_query.query.clone(), None, "query");
+        get_sparse_vector(parsed_query.query.clone(), fulltext_boost, "query");
 
     let (dense_vector, sparse_vector) = futures::try_join!(
         dense_embedding_vectors_future,

--- a/server/static/output.css
+++ b/server/static/output.css
@@ -1,5 +1,113 @@
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
 /*
-! tailwindcss v3.4.10 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -442,116 +550,8 @@ video {
 
 /* Make elements with the HTML hidden attribute stay hidden by default */
 
-[hidden] {
+[hidden]:where(:not([hidden="until-found"])) {
   display: none;
-}
-
-*, ::before, ::after {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
-}
-
-::backdrop {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
 }
 
 .static {
@@ -813,7 +813,7 @@ video {
 
 .border-gray-200 {
   --tw-border-opacity: 1;
-  border-color: rgb(229 231 235 / var(--tw-border-opacity));
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
 }
 
 .border-transparent {
@@ -822,12 +822,12 @@ video {
 
 .bg-gray-100 {
   --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gray-200 {
   --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
 }
 
 .object-cover {
@@ -924,17 +924,17 @@ video {
 
 .text-gray-500 {
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-700 {
   --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
 
 .text-white {
   --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
 .underline {
@@ -958,17 +958,17 @@ video {
 
 .dark\:border-gray-600:is(.dark *) {
   --tw-border-opacity: 1;
-  border-color: rgb(75 85 99 / var(--tw-border-opacity));
+  border-color: rgb(75 85 99 / var(--tw-border-opacity, 1));
 }
 
 .dark\:text-gray-200:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgb(229 231 235 / var(--tw-text-opacity));
+  color: rgb(229 231 235 / var(--tw-text-opacity, 1));
 }
 
 .dark\:text-gray-300:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 
 @media (min-width: 640px) {

--- a/server/static/output.css
+++ b/server/static/output.css
@@ -1,113 +1,5 @@
-*, ::before, ::after {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
-}
-
-::backdrop {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
-}
-
 /*
-! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.10 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -550,8 +442,116 @@ video {
 
 /* Make elements with the HTML hidden attribute stay hidden by default */
 
-[hidden]:where(:not([hidden="until-found"])) {
+[hidden] {
   display: none;
+}
+
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
 }
 
 .static {
@@ -813,7 +813,7 @@ video {
 
 .border-gray-200 {
   --tw-border-opacity: 1;
-  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  border-color: rgb(229 231 235 / var(--tw-border-opacity));
 }
 
 .border-transparent {
@@ -822,12 +822,12 @@ video {
 
 .bg-gray-100 {
   --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
 
 .bg-gray-200 {
   --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 
 .object-cover {
@@ -924,17 +924,17 @@ video {
 
 .text-gray-500 {
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+  color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
 .text-gray-700 {
   --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+  color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
 .text-white {
   --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
 .underline {
@@ -958,17 +958,17 @@ video {
 
 .dark\:border-gray-600:is(.dark *) {
   --tw-border-opacity: 1;
-  border-color: rgb(75 85 99 / var(--tw-border-opacity, 1));
+  border-color: rgb(75 85 99 / var(--tw-border-opacity));
 }
 
 .dark\:text-gray-200:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgb(229 231 235 / var(--tw-text-opacity, 1));
+  color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
 .dark\:text-gray-300:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+  color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
- **feat: add fulltext_content field to ChunkReqPayload and related structures**
- **cleanup: filter out collapsed queries for query counts**
- **hack: hard swap reranker url if it matches to the k8s dns name. it should instead use the environment variable just in case the k8s dns name gets changed**
- **feature: add autocomplete search over groups**
- **feature: add autocomplete search over groups to the frontend**
- **feature: add api key pagination**
- **bugfix: generate openapi types for sdk**
- **feature: dedup autocomplete by group and add api key filtering for that route**
- **feature: patch metadata into `SearchOverGroupsReqPayload`**
- **feature(docker): update subtrace version to b314**
- **feature: sync-qdrant  add prints for totals**
- **feauture: sync-qdrant script workign now will clean up later**

## Please indicate what issue this PR is related to and @ any maintainers who are relevant
