### PR TITLE
sec: bump permission on creating an `organization_api_key`

### DIFF
--- a/server/src/handlers/organization_handler.rs
+++ b/server/src/handlers/organization_handler.rs
@@ -453,7 +453,7 @@ pub struct CreateApiKeyResponse {
     )
 )]
 pub async fn create_organization_api_key(
-    _user: LoggedUser,
+    _user: AdminOnly,
     data: web::Json<CreateApiKeyReqPayload>,
     organization: OrganizationWithSubAndPlan,
     pool: web::Data<Pool>,


### PR DESCRIPTION
The ability to create organization api keys should only be allowed for Admin users
or greater. This is a security feature to prevent generating arbitrary keys from an unscoped
read-only user api key.