### PR TITLE
fix(ts-sdk): correct crawl module bugs and add createCrawl wrapper

### DIFF
--- a/clients/ts-sdk/src/functions/crawl/crawl.test.ts
+++ b/clients/ts-sdk/src/functions/crawl/crawl.test.ts
@@ -1,0 +1,21 @@
+import { beforeAll, describe, expectTypeOf } from "vitest";
+import { TrieveSDK } from "../../sdk";
+import { CrawlRequest } from "../../types.gen";
+import { TRIEVE } from "../../__tests__/constants";
+import { test } from "../../__tests__/utils";
+
+describe("Crawl Tests", async () => {
+  let trieve: TrieveSDK;
+  beforeAll(() => {
+    trieve = TRIEVE;
+  });
+
+  test("getCrawlsForDataset", async () => {
+    const data = await trieve.getCrawlsForDataset({
+      page: 1,
+      limit: 10,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Array<CrawlRequest>>();
+  });
+});

--- a/clients/ts-sdk/src/functions/crawl/index.ts
+++ b/clients/ts-sdk/src/functions/crawl/index.ts
@@ -7,28 +7,30 @@
 import { TrieveSDK } from "../../sdk";
 import {
   $OpenApiTs,
-  Dataset,
+  CreateCrawlReqPayload,
+  CrawlRequest,
   GetCrawlRequestsForDatasetData,
 } from "../../types.gen";
 
 /**
- * Function that provides the ability to create a dataset. This function is used to create a new dataset in the organization.
+ * Function that retrieves all crawl requests for the current dataset, with optional pagination.
  *
  * Example:
  * ```js
- * const dataset = await trieve.createDataset({
- *  dataset_name: "My Dataset",
+ * const crawls = await trieve.getCrawlsForDataset({
+ *   page: 1,
+ *   limit: 10,
  * });
  * ```
  */
 export async function getCrawlsForDataset(
   /** @hidden */
   this: TrieveSDK,
-  props: GetCrawlRequestsForDatasetData,
+  props: Omit<GetCrawlRequestsForDatasetData, "trDataset"> = {},
   signal?: AbortSignal,
-): Promise<Dataset> {
+): Promise<Array<CrawlRequest>> {
   if (!this.datasetId) {
-    throw new Error("Dataset ID is required to create a crawl");
+    throw new Error("Dataset ID is required to get crawls");
   }
 
   return this.trieve.fetch<"eject">(
@@ -37,9 +39,41 @@ export async function getCrawlsForDataset(
     }` as keyof $OpenApiTs,
     "get",
     {
+      datasetId: this.datasetId,
+    },
+    signal,
+  ) as Promise<Array<CrawlRequest>>;
+}
+
+/**
+ * Function that creates a new crawl request for the current dataset.
+ *
+ * Example:
+ * ```js
+ * const crawl = await trieve.createCrawl({
+ *   crawl_options: {
+ *     site_url: "https://example.com",
+ *   },
+ * });
+ * ```
+ */
+export async function createCrawl(
+  /** @hidden */
+  this: TrieveSDK,
+  props: CreateCrawlReqPayload,
+  signal?: AbortSignal,
+): Promise<CrawlRequest> {
+  if (!this.datasetId) {
+    throw new Error("Dataset ID is required to create a crawl");
+  }
+
+  return this.trieve.fetch(
+    "/api/crawl",
+    "post",
+    {
       data: props,
       datasetId: this.datasetId,
     },
     signal,
-  ) as Promise<Dataset>;
+  ) as Promise<CrawlRequest>;
 }


### PR DESCRIPTION
The crawl module under `clients/ts-sdk/src/functions/crawl/` was cargo-culted from the datasets module and never updated. As shipped on main, `getCrawlsForDataset` returns a value typed as `Promise<Dataset>` (a single dataset), the JSDoc on it claims it creates a dataset, and the error message says it needs a dataset ID "to create a crawl" even though it's a GET. There's also no SDK wrapper for `POST /api/crawl`.

This PR fixes the wrong types, JSDoc, and error message on `getCrawlsForDataset`, makes its `props` argument optional (both `limit` and `page` are already optional in the underlying type), and adds a wrapper for `createCrawl` that mirrors the patterns used in the other function modules.

It also adds `clients/ts-sdk/src/functions/crawl/crawl.test.ts` with a read-only smoke + return-type test for `getCrawlsForDataset`, modeled on the existing `events.test.ts`/`analytics.test.ts` pattern. Nothing in the test creates or mutates crawls, so it's safe against the shared sandbox dataset.

`yarn build` and `yarn lint` both pass.

## What's intentionally not in this PR

The OpenAPI spec also exposes `PUT /api/crawl` and `DELETE /api/crawl/{crawl_id}`. I started by wrapping all four endpoints, but on closer reading of the backend the PUT and DELETE handlers look broken in ways that would mislead SDK callers, so I dropped those wrappers from this PR. Filing them here for the maintainers in case it's useful:

- **`delete_crawl_request`** (`server/src/handlers/crawl_handler.rs:132`) doesn't extract `DatasetAndOrgWithSubAndPlan` and `delete_crawl_query` runs `DELETE FROM crawl_requests WHERE id = crawl_id` with no `dataset_id` filter (`server/src/operators/crawl_operator.rs:415`). Combined with `AdminOnly` only checking that the caller is admin somewhere, that means an admin for any dataset can delete crawls from any other dataset by passing their `crawl_id`. The documented `TR-Dataset` header is ignored.
- **`update_crawl_request`** (`server/src/handlers/crawl_handler.rs:91`) takes `crawl_id` in the payload, but `update_crawl_query` (`server/src/operators/crawl_operator.rs:354`) loads the **first** crawl in the dataset (no filter on `crawl_id`), then deletes by `scrape_id == crawl_id` (not `id == crawl_id`), then creates a new crawl. In the common case where the caller passes the value of `CrawlRequest.id` as `crawl_id` (which is what the OpenAPI type implies), the delete-by-`scrape_id` doesn't match anything and the "first crawl in dataset" load is unrelated to the id the caller actually wanted to update.

Happy to follow up with a server-side PR for either of these if it's something the maintainers want; for now this PR sticks to changes that don't require a backend fix to be safe.