### PR TITLE
test(ts-sdk): replace duplicate datasets test with real dataset coverage

### DIFF
--- a/clients/ts-sdk/src/functions/datasets/datasets.test.ts
+++ b/clients/ts-sdk/src/functions/datasets/datasets.test.ts
@@ -1,17 +1,50 @@
 import { beforeAll, describe, expectTypeOf } from "vitest";
 import { TrieveSDK } from "../../sdk";
-import { EventReturn } from "../../types.gen";
+import {
+  Dataset,
+  DatasetAndUsage,
+  DatasetQueueLengthsResponse,
+  DatasetUsageCount,
+  GetAllTagsResponse,
+} from "../../types.gen";
 import { TRIEVE } from "../../__tests__/constants";
 import { test } from "../../__tests__/utils";
 
-describe("Events Tests", async () => {
+describe("Dataset Tests", async () => {
   let trieve: TrieveSDK;
   beforeAll(() => {
     trieve = TRIEVE;
   });
 
-  test("getEventsForDataset", async () => {
-    const data = await trieve.getEventsForDataset({});
-    expectTypeOf(data).toEqualTypeOf<EventReturn>();
+  test("getDatasetById", async () => {
+    const data = await trieve.getDatasetById(trieve.datasetId!);
+    expectTypeOf(data).toEqualTypeOf<Dataset>();
+  });
+
+  test("getDatasetUsageById", async () => {
+    const data = await trieve.getDatasetUsageById(trieve.datasetId!);
+    expectTypeOf(data).toEqualTypeOf<DatasetUsageCount>();
+  });
+
+  test("getDatasetsFromOrganization", async () => {
+    const data = await trieve.getDatasetsFromOrganization(
+      trieve.organizationId!,
+    );
+    expectTypeOf(data).toEqualTypeOf<DatasetAndUsage[]>();
+  });
+
+  test("getAllDatasetTags", async () => {
+    const data = await trieve.getAllDatasetTags(
+      {
+        page: 1,
+      },
+      trieve.datasetId!,
+    );
+    expectTypeOf(data).toEqualTypeOf<GetAllTagsResponse>();
+  });
+
+  test("getDatasetQueueLengths", async () => {
+    const data = await trieve.getDatasetQueueLengths(trieve.datasetId!);
+    expectTypeOf(data).toEqualTypeOf<DatasetQueueLengthsResponse>();
   });
 });


### PR DESCRIPTION
`clients/ts-sdk/src/functions/datasets/datasets.test.ts` on main is a verbatim copy of `events.test.ts`: same `describe("Events Tests")` block, same `getEventsForDataset({})` body, same `EventReturn` type assertion. None of the 14 functions exported by `functions/datasets/index.ts` are actually exercised, so the datasets module shows up as "tested" without having any coverage at all.

This PR rewrites the file to actually test the datasets module, using the same `expectTypeOf` pattern as `chunkGroup.test.ts`, `analytics.test.ts`, etc.

Added coverage:

- `getDatasetById`
- `getDatasetUsageById`
- `getDatasetsFromOrganization`
- `getAllDatasetTags`
- `getDatasetQueueLengths`

The destructive functions (`createDataset`, `updateDataset`, `batchCreateDatasets`, `clearDataset`, `deleteDataset`) are intentionally not in here. Running them on every PR against the shared sandbox dataset would either leak data or wipe fixtures the rest of the test files rely on.

`yarn build` and `yarn lint` both pass.